### PR TITLE
Fix: Add case-insensitive hashID and none not displaying correctly

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -551,7 +551,7 @@ list cat:food,transport             # Show food AND transport transactions
 summarize cat:food,transport,health # Summary across three categories
 ```
 
-> **Note:** The `none` and `(none)` values are reserved keywords that match transactions with **no category assigned**. To find transactions in a category named `salary`, use `cat:salary` explicitly.
+> **Note:** `none` and `(none)` are reserved keywords. They cannot be used as category names when adding transactions, and using `cat:none` or `cat:(none)` in filters will show only transactions with no category assigned.
 
 ---
 
@@ -688,9 +688,9 @@ Budget definitions and amounts are preserved. Only transaction data is deleted. 
 
 ---
 
-**Q: Why does `list cat:none` not show my uncategorised transactions?**
+**Q: Can I name a category "none" or "(none)"?**
 
-`none` and `(none)` are reserved keywords that match transactions with **no category at all**. If your transaction has an explicit category label (e.g. `salary`), use `list cat:salary` to find it.
+No. These are reserved keywords that represent transactions with no category. The application prevents you from creating a category with these names, and using `list cat:none` or `list cat:(none)` will show only transactions that have no category assigned.
 
 ---
 

--- a/src/main/java/seedu/RLAD/Transaction.java
+++ b/src/main/java/seedu/RLAD/Transaction.java
@@ -55,8 +55,8 @@ public class Transaction {
         return String.format("[%s] %s | %s | $%.2f | %s | %s",
                 hashId, type.toUpperCase(), date, amount, category, description);
     }
-
+    // HashID must be lowercase only!
     public void regenerateHashId() {
-        this.hashId = UUID.randomUUID().toString().substring(0, 6);
+        this.hashId = UUID.randomUUID().toString().substring(0, 6).toLowerCase();
     }
 }

--- a/src/main/java/seedu/RLAD/TransactionManager.java
+++ b/src/main/java/seedu/RLAD/TransactionManager.java
@@ -95,6 +95,8 @@ public class TransactionManager {
      * TODO: Replace O(N) list search with a HashSet for O(1) lookups to improve scaling.
      */
     private boolean idExists(String hashId) {
+        // allows for case-insensitive input
+        hashId = hashId.toLowerCase();
         return transMap.containsKey(hashId);
     }
 
@@ -114,6 +116,8 @@ public class TransactionManager {
      * @return the Transaction if found, null otherwise
      */
     public Transaction findTransaction(String id) {
+        // allows for case-insensitive input
+        id = id.toLowerCase();
         return transMap.containsKey(id) ? transMap.get(id) : null;
     }
 
@@ -124,6 +128,8 @@ public class TransactionManager {
      * @return true if deletion was successful, false if ID not found
      */
     public boolean deleteTransaction(String id) {
+        // allows for case-insensitive input
+        id = id.toLowerCase();
         Transaction toDelete = findTransaction(id);
         if (toDelete != null) {
             transactions.remove(toDelete);
@@ -148,6 +154,8 @@ public class TransactionManager {
      * @return true if update was successful, false if ID not found
      */
     public boolean updateTransaction(String id, Transaction updated) {
+        // allows for case-insensitive input
+        id = id.toLowerCase();
         Transaction old = findTransaction(id);
         if (old != null) {
             // 1. Update the Map

--- a/src/main/java/seedu/RLAD/command/AddCommand.java
+++ b/src/main/java/seedu/RLAD/command/AddCommand.java
@@ -84,6 +84,9 @@ public class AddCommand extends Command {
         String category = optionalFields.category;
         String description = optionalFields.description;
 
+        // Validate category is not a reserved keyword
+        validateCategory(category);
+
         // Create and add the transaction
         Transaction newTransaction = new Transaction(type, category, amount, date, description);
         transactions.addTransaction(newTransaction);
@@ -256,6 +259,24 @@ public class AddCommand extends Command {
                 "  add credit 3000 2026-03-01 salary \"March salary\"\n" +
                 "  add debit 15.50 2026-03-05 food \"Chicken rice\"\n" +
                 "  add debit 5.00 2026-03-06";
+    }
+
+    /**
+     * Validates that the category is not a reserved keyword.
+     * Reserved keywords: "none", "(none)"
+     *
+     * @param category The category to validate (may be null)
+     * @throws RLADException If category is a reserved keyword
+     */
+    private void validateCategory(String category) throws RLADException {
+        if (category == null) {
+            return;
+        }
+        String trimmed = category.trim();
+        if (trimmed.equalsIgnoreCase("none") || trimmed.equalsIgnoreCase("(none)")) {
+            throw new RLADException("'" + category + "' is a reserved keyword. "
+                    + "Use a different category name or omit the category.");
+        }
     }
 
     /**

--- a/src/main/java/seedu/RLAD/command/DeleteCommand.java
+++ b/src/main/java/seedu/RLAD/command/DeleteCommand.java
@@ -48,8 +48,8 @@ public class DeleteCommand extends Command {
             throw new RLADException(getUsageHelp());
         }
 
-        // Clean and extract HashID (remove any extra whitespace)
-        String hashId = rawArgs.trim();
+        // Clean and extract HashID case (remove any extra whitespace and make case insensitive)
+        String hashId = rawArgs.trim().toLowerCase();
 
         // Find the transaction
         Transaction toDelete = transactions.findTransaction(hashId);

--- a/src/main/java/seedu/RLAD/command/FilterCommand.java
+++ b/src/main/java/seedu/RLAD/command/FilterCommand.java
@@ -299,10 +299,16 @@ public class FilterCommand extends Command {
                 break;
             case "cat":
             case "category":
-                result = result.stream()
-                        .filter(t -> t.getCategory() != null
-                                && t.getCategory().toLowerCase().contains(value))
-                        .collect(Collectors.toList());
+                if (value.trim().equalsIgnoreCase("none") || value.trim().equalsIgnoreCase("(none)")) {
+                    result = result.stream()
+                            .filter(t -> t.getCategory() == null || t.getCategory().isBlank())
+                            .collect(Collectors.toList());
+                } else {
+                    result = result.stream()
+                            .filter(t -> t.getCategory() != null
+                                    && t.getCategory().toLowerCase().contains(value))
+                            .collect(Collectors.toList());
+                }
                 break;
             case "from":
                 LocalDate fromDate = parseColonDate(value);

--- a/src/main/java/seedu/RLAD/command/ModifyCommand.java
+++ b/src/main/java/seedu/RLAD/command/ModifyCommand.java
@@ -31,7 +31,8 @@ public class ModifyCommand extends Command {
         }
 
         String[] parts = rawArgs.trim().split("\\s+", 2);
-        String id = parts[0];
+        // Allows for uppercase and lowercase hashID in the input
+        String id = parts[0].toLowerCase();
         String updatesStr = parts.length > 1 ? parts[1] : "";
 
         Transaction existing = transactions.findTransaction(id);

--- a/src/test/java/seedu/RLAD/TransactionManagerTest.java
+++ b/src/test/java/seedu/RLAD/TransactionManagerTest.java
@@ -119,4 +119,133 @@ public class TransactionManagerTest {
     void addTransaction_notifiesBudgetManager() {
         // TODO: Implement mock BudgetManager to verify notification signal
     }
+
+    // ===== Case-insensitive HashID Tests =====
+
+    @Test
+    void findTransaction_uppercaseInput_matchesLowercaseStoredId() {
+        Transaction t = new Transaction("debit", "food", 10.0, LocalDate.now(), "Lunch");
+        tm.addTransaction(t);
+
+        String storedId = t.getHashId(); // stored as lowercase
+        String uppercaseInput = storedId.toUpperCase();
+
+        assertNotNull(tm.findTransaction(uppercaseInput),
+                "Should find transaction using uppercase hashID");
+    }
+
+    @Test
+    void findTransaction_mixedCaseInput_matchesLowercaseStoredId() {
+        Transaction t = new Transaction("debit", "food", 10.0, LocalDate.now(), "Lunch");
+        tm.addTransaction(t);
+
+        String storedId = t.getHashId(); // stored as lowercase
+        String mixedCaseInput = storedId.substring(0, 3).toUpperCase()
+                + storedId.substring(3).toLowerCase();
+
+        assertNotNull(tm.findTransaction(mixedCaseInput),
+                "Should find transaction using mixed-case hashID");
+    }
+
+    @Test
+    void findTransaction_lowercaseInput_stillMatches() {
+        Transaction t = new Transaction("debit", "food", 10.0, LocalDate.now(), "Lunch");
+        tm.addTransaction(t);
+
+        String storedId = t.getHashId(); // stored as lowercase
+
+        assertNotNull(tm.findTransaction(storedId),
+                "Should find transaction using exact lowercase hashID");
+    }
+
+    @Test
+    void deleteTransaction_uppercaseInput_deletesCorrectTransaction() {
+        Transaction t = new Transaction("debit", "food", 10.0, LocalDate.now(), "Lunch");
+        tm.addTransaction(t);
+
+        String storedId = t.getHashId();
+        String uppercaseInput = storedId.toUpperCase();
+
+        assertTrue(tm.deleteTransaction(uppercaseInput),
+                "Delete should succeed with uppercase hashID");
+        assertNull(tm.findTransaction(storedId),
+                "Transaction should no longer exist after deletion");
+        assertEquals(0, tm.getTransactions().size(),
+                "All transactions should be deleted");
+    }
+
+    @Test
+    void deleteTransaction_mixedCaseInput_deletesCorrectTransaction() {
+        Transaction t = new Transaction("debit", "food", 10.0, LocalDate.now(), "Lunch");
+        tm.addTransaction(t);
+
+        String storedId = t.getHashId();
+        String mixedCaseInput = storedId.substring(0, 2).toUpperCase()
+                + storedId.substring(2);
+
+        assertTrue(tm.deleteTransaction(mixedCaseInput),
+                "Delete should succeed with mixed-case hashID");
+        assertNull(tm.findTransaction(storedId),
+                "Transaction should no longer exist after deletion");
+    }
+
+    @Test
+    void updateTransaction_uppercaseInput_updatesCorrectTransaction() {
+        Transaction oldT = new Transaction("debit", "food", 10.0, LocalDate.now(), "Original");
+        tm.addTransaction(oldT);
+
+        String storedId = oldT.getHashId();
+        String uppercaseInput = storedId.toUpperCase();
+
+        Transaction updated = new Transaction("credit", "salary", 50.0, LocalDate.now(), "Updated");
+        updated.setHashId(storedId);
+
+        assertTrue(tm.updateTransaction(uppercaseInput, updated),
+                "Update should succeed with uppercase hashID");
+        assertEquals("Updated", tm.findTransaction(storedId).getDescription(),
+                "Transaction description should be updated");
+    }
+
+    @Test
+    void updateTransaction_mixedCaseInput_updatesCorrectTransaction() {
+        Transaction oldT = new Transaction("debit", "food", 10.0, LocalDate.now(), "Original");
+        tm.addTransaction(oldT);
+
+        String storedId = oldT.getHashId();
+        String mixedCaseInput = storedId.substring(0, 4).toUpperCase()
+                + storedId.substring(4).toLowerCase();
+
+        Transaction updated = new Transaction("credit", "salary", 50.0, LocalDate.now(), "Updated");
+        updated.setHashId(storedId);
+
+        assertTrue(tm.updateTransaction(mixedCaseInput, updated),
+                "Update should succeed with mixed-case hashID");
+        assertEquals("Updated", tm.findTransaction(storedId).getDescription(),
+                "Transaction description should be updated");
+    }
+
+    @Test
+    void findTransaction_allCaseVariations_findSameTransaction() {
+        Transaction t = new Transaction("debit", "food", 10.0, LocalDate.now(), "Lunch");
+        tm.addTransaction(t);
+
+        String storedId = t.getHashId();
+        String uppercase = storedId.toUpperCase();
+        String lowercase = storedId.toLowerCase();
+        String mixedCase = storedId.substring(0, 2).toUpperCase()
+                + storedId.substring(2, 4).toLowerCase()
+                + storedId.substring(4).toUpperCase();
+
+        Transaction foundUpper = tm.findTransaction(uppercase);
+        Transaction foundLower = tm.findTransaction(lowercase);
+        Transaction foundMixed = tm.findTransaction(mixedCase);
+
+        assertNotNull(foundUpper, "Uppercase should match");
+        assertNotNull(foundLower, "Lowercase should match");
+        assertNotNull(foundMixed, "Mixed case should match");
+
+        assertEquals(t.getHashId(), foundUpper.getHashId(), "All variants should return same transaction");
+        assertEquals(t.getHashId(), foundLower.getHashId(), "All variants should return same transaction");
+        assertEquals(t.getHashId(), foundMixed.getHashId(), "All variants should return same transaction");
+    }
 }

--- a/src/test/java/seedu/RLAD/command/AddCommandTest.java
+++ b/src/test/java/seedu/RLAD/command/AddCommandTest.java
@@ -72,6 +72,56 @@ public class AddCommandTest {
             System.out.println("✓ PASS (Expected - Invalid type): " + e.getMessage() + "\n");
         }
 
+        // Test 7: Reserved category keyword "none"
+        System.out.println("Test 7: Reserved category keyword 'none'");
+        try {
+            AddCommand cmd7 = new AddCommand("debit 10.00 2026-03-05 none \"literal none\"");
+            cmd7.execute(tm, ui);
+            System.out.println("✗ FAIL (Expected to throw exception but didn't)\n");
+        } catch (RLADException e) {
+            System.out.println("✓ PASS (Expected - Reserved keyword): " + e.getMessage() + "\n");
+        }
+
+        // Test 8: Reserved category keyword "(none)"
+        System.out.println("Test 8: Reserved category keyword '(none)'");
+        try {
+            AddCommand cmd8 = new AddCommand("debit 10.00 2026-03-05 (none) \"literal (none)\"");
+            cmd8.execute(tm, ui);
+            System.out.println("✗ FAIL (Expected to throw exception but didn't)\n");
+        } catch (RLADException e) {
+            System.out.println("✓ PASS (Expected - Reserved keyword): " + e.getMessage() + "\n");
+        }
+
+        // Test 9: Reserved keyword case-insensitive "NONE"
+        System.out.println("Test 9: Reserved keyword case-insensitive 'NONE'");
+        try {
+            AddCommand cmd9 = new AddCommand("debit 10.00 2026-03-05 NONE \"uppercase none\"");
+            cmd9.execute(tm, ui);
+            System.out.println("✗ FAIL (Expected to throw exception but didn't)\n");
+        } catch (RLADException e) {
+            System.out.println("✓ PASS (Expected - Reserved keyword): " + e.getMessage() + "\n");
+        }
+
+        // Test 10: Valid category not rejected
+        System.out.println("Test 10: Valid category 'food' not rejected");
+        try {
+            AddCommand cmd10 = new AddCommand("debit 10.00 2026-03-05 food \"regular food\"");
+            cmd10.execute(tm, ui);
+            System.out.println("✓ PASS\n");
+        } catch (RLADException e) {
+            System.out.println("✗ FAIL: " + e.getMessage() + "\n");
+        }
+
+        // Test 11: Null category not rejected
+        System.out.println("Test 11: Null category not rejected");
+        try {
+            AddCommand cmd11 = new AddCommand("debit 10.00 2026-03-05");
+            cmd11.execute(tm, ui);
+            System.out.println("✓ PASS\n");
+        } catch (RLADException e) {
+            System.out.println("✗ FAIL: " + e.getMessage() + "\n");
+        }
+
         // Show final transactions
         System.out.println("\n=== FINAL TRANSACTIONS ===");
         if (tm.getTransactions().isEmpty()) {


### PR DESCRIPTION
-**Fixed case-insensitive hashID**.
Closes #91
JUnit tests included under `TransactionManagerTest`
PS: the issue should have been named
```[PE-D][Tester C] Delete is case SENSITIVE```

Closes #115 
  - **Fixed `list cat:none` / `list cat:(none)`** 
  `FilterCommand.applyColonFilters()` now correctly returns uncategorized
  transactions (null/blank category) instead of treating these as literal string
   matches
  - **Updated UserGuide** documentation to reflect reserved keywords
