### PR TITLE
Fix export/import to use positional args per UG

### DIFF
--- a/src/main/java/seedu/RLAD/Ui.java
+++ b/src/main/java/seedu/RLAD/Ui.java
@@ -353,6 +353,19 @@ public class Ui {
     }
 
     /**
+     * Asks the user a yes/no question and returns their response.
+     *
+     * @param prompt the question to display
+     * @return true if the user answered 'y' or 'yes', false otherwise
+     */
+    public boolean askYesNo(String prompt) {
+        System.out.println(prompt + " (y/n): ");
+        System.out.print("> ");
+        String input = userScanner.nextLine().trim().toLowerCase();
+        return input.equals("y") || input.equals("yes");
+    }
+
+    /**
      * Prints the output of a command (default implementation).
      *
      * @param command The command whose output to display

--- a/src/main/java/seedu/RLAD/command/ExportCommand.java
+++ b/src/main/java/seedu/RLAD/command/ExportCommand.java
@@ -6,6 +6,10 @@ import seedu.RLAD.Ui;
 import seedu.RLAD.exception.RLADException;
 import seedu.RLAD.storage.CsvStorageManager;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -34,6 +38,23 @@ public class ExportCommand extends Command {
                     + LocalDate.now().format(DateTimeFormatter.ISO_LOCAL_DATE) + ".csv";
         }
 
+        Path path = Paths.get(filename);
+        validateNoDataDirectory(path);
+
+        Path parent = path.getParent();
+        if (parent != null && !Files.isDirectory(parent)) {
+            boolean create = ui.askYesNo("Directory '" + parent + "' does not exist. Create it?");
+            if (!create) {
+                ui.showResult("Export cancelled.");
+                return;
+            }
+            try {
+                Files.createDirectories(parent);
+            } catch (IOException e) {
+                throw new RLADException("Failed to create directory: " + e.getMessage());
+            }
+        }
+
         ArrayList<Transaction> txns = transactions.getTransactions();
         if (txns.isEmpty()) {
             ui.showResult("No transactions to export.");
@@ -41,7 +62,26 @@ public class ExportCommand extends Command {
         }
 
         CsvStorageManager.exportToCsv(txns, filename);
-        ui.showResult("Exported " + txns.size() + " transactions to: ./" + filename);
+        ui.showResult("Exported " + txns.size() + " transactions to: " + path.toAbsolutePath());
+    }
+
+    /**
+     * Validates that no component of the path is the reserved directory name "data".
+     *
+     * @param path the export path to check
+     * @throws RLADException if a path component is named "data"
+     */
+    private void validateNoDataDirectory(Path path) throws RLADException {
+        Path parent = path.getParent();
+        if (parent == null) {
+            return;
+        }
+        for (Path component : parent) {
+            if (component.toString().equalsIgnoreCase("data")) {
+                throw new RLADException("'data' is a reserved directory name used for backups. "
+                        + "Please use a different directory name.");
+            }
+        }
     }
 
     @Override

--- a/src/main/java/seedu/RLAD/command/ExportCommand.java
+++ b/src/main/java/seedu/RLAD/command/ExportCommand.java
@@ -6,23 +6,21 @@ import seedu.RLAD.Ui;
 import seedu.RLAD.exception.RLADException;
 import seedu.RLAD.storage.CsvStorageManager;
 
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.Map;
 
 /**
  * Exports all transactions to a CSV file.
+ * Syntax: export [filename]
+ * If no filename is given, defaults to transactions_YYYY-MM-DD.csv in the current directory.
  */
 public class ExportCommand extends Command {
 
     /**
      * Creates a new ExportCommand.
      *
-     * @param rawArgs the raw argument string
+     * @param rawArgs the raw argument string (optional filename)
      */
     public ExportCommand(String rawArgs) {
         super(rawArgs);
@@ -30,24 +28,10 @@ public class ExportCommand extends Command {
 
     @Override
     public void execute(TransactionManager transactions, Ui ui) throws RLADException {
-        Map<String, String> flags = FilterCommand.parseFlags(rawArgs);
-
-        String filename = stripQuotes(flags.getOrDefault("file",
-                "transactions_" + LocalDate.now().format(DateTimeFormatter.ISO_LOCAL_DATE) + ".csv"));
-        if (filename.isBlank()) {
-            throw new RLADException("--file requires a filename. "
-                    + "Example: export --file transactions.csv");
-        }
-
-        String directory = stripQuotes(flags.getOrDefault("path", "."));
-        if (directory.isBlank()) {
-            throw new RLADException("--path requires a directory. "
-                    + "Example: export --path ./data");
-        }
-
-        Path dirPath = Paths.get(directory);
-        if (!Files.isDirectory(dirPath)) {
-            throw new RLADException("Directory does not exist: " + directory);
+        String filename = rawArgs == null ? "" : rawArgs.trim();
+        if (filename.isEmpty()) {
+            filename = "transactions_"
+                    + LocalDate.now().format(DateTimeFormatter.ISO_LOCAL_DATE) + ".csv";
         }
 
         ArrayList<Transaction> txns = transactions.getTransactions();
@@ -56,17 +40,8 @@ public class ExportCommand extends Command {
             return;
         }
 
-        String fullPath = dirPath.resolve(filename).toString();
-        CsvStorageManager.exportToCsv(txns, fullPath);
-
-        ui.showResult("Exported " + txns.size() + " transactions to: " + fullPath);
-    }
-
-    private static String stripQuotes(String value) {
-        if (value.length() >= 2 && value.startsWith("\"") && value.endsWith("\"")) {
-            return value.substring(1, value.length() - 1);
-        }
-        return value;
+        CsvStorageManager.exportToCsv(txns, filename);
+        ui.showResult("Exported " + txns.size() + " transactions to: " + filename);
     }
 
     @Override

--- a/src/main/java/seedu/RLAD/command/ExportCommand.java
+++ b/src/main/java/seedu/RLAD/command/ExportCommand.java
@@ -41,7 +41,7 @@ public class ExportCommand extends Command {
         }
 
         CsvStorageManager.exportToCsv(txns, filename);
-        ui.showResult("Exported " + txns.size() + " transactions to: " + filename);
+        ui.showResult("Exported " + txns.size() + " transactions to: ./" + filename);
     }
 
     @Override

--- a/src/main/java/seedu/RLAD/command/ImportCommand.java
+++ b/src/main/java/seedu/RLAD/command/ImportCommand.java
@@ -8,17 +8,17 @@ import seedu.RLAD.storage.CsvStorageManager;
 
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.Map;
 
 /**
  * Imports transactions from a CSV file, either replacing or merging with existing data.
+ * Syntax: import &lt;filename&gt; [merge]
  */
 public class ImportCommand extends Command {
 
     /**
      * Creates a new ImportCommand.
      *
-     * @param rawArgs the raw argument string
+     * @param rawArgs the raw argument string (filename and optional merge keyword)
      */
     public ImportCommand(String rawArgs) {
         super(rawArgs);
@@ -26,15 +26,21 @@ public class ImportCommand extends Command {
 
     @Override
     public void execute(TransactionManager transactions, Ui ui) throws RLADException {
-        Map<String, String> flags = FilterCommand.parseFlags(rawArgs);
+        String args = rawArgs == null ? "" : rawArgs.trim();
 
-        String filePath = flags.get("file");
-        if (filePath == null || filePath.isBlank()) {
-            throw new RLADException("--file is required for import. "
-                    + "Usage: import --file FILENAME [--merge]");
+        boolean mergeMode = false;
+        if (args.toLowerCase().endsWith(" merge")) {
+            mergeMode = true;
+            args = args.substring(0, args.length() - " merge".length()).trim();
+        } else if (args.equalsIgnoreCase("merge")) {
+            args = "";
         }
 
-        boolean mergeMode = flags.containsKey("merge");
+        if (args.isBlank()) {
+            throw new RLADException("Usage: import <filename> [merge]");
+        }
+
+        String filePath = args;
 
         if (!Files.exists(Paths.get(filePath))) {
             throw new RLADException("File not found: " + filePath);
@@ -44,7 +50,7 @@ public class ImportCommand extends Command {
             boolean confirmed = ui.askConfirmation(
                     "WARNING: Replace mode will delete all "
                             + transactions.getTransactionCount() + " existing transactions.\n"
-                            + "Use --merge to add to existing data instead.");
+                            + "Use merge to add to existing data instead.");
             if (!confirmed) {
                 ui.showResult("Import cancelled.");
                 return;

--- a/src/test/java/seedu/RLAD/command/ExportCommandTest.java
+++ b/src/test/java/seedu/RLAD/command/ExportCommandTest.java
@@ -17,6 +17,8 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ExportCommandTest {
@@ -25,13 +27,15 @@ class ExportCommandTest {
     Path tempDir;
 
     private TransactionManager tm;
-    private Ui ui;
+
+    private Ui uiWith(String input) {
+        System.setIn(new ByteArrayInputStream(input.getBytes()));
+        return new Ui();
+    }
 
     @BeforeEach
     void setUp() {
         tm = new TransactionManager();
-        System.setIn(new ByteArrayInputStream("".getBytes()));
-        ui = new Ui();
     }
 
     @Test
@@ -43,7 +47,7 @@ class ExportCommandTest {
 
         Path outFile = tempDir.resolve("out.csv");
         ExportCommand cmd = new ExportCommand(outFile.toString());
-        cmd.execute(tm, ui);
+        cmd.execute(tm, uiWith(""));
 
         assertTrue(Files.exists(outFile));
         List<String> lines = Files.readAllLines(outFile);
@@ -55,8 +59,8 @@ class ExportCommandTest {
     void execute_emptyTransactions_noFileCreated() throws RLADException {
         Path outFile = tempDir.resolve("out.csv");
         ExportCommand cmd = new ExportCommand(outFile.toString());
-        cmd.execute(tm, ui);
-        assertTrue(!Files.exists(outFile));
+        cmd.execute(tm, uiWith(""));
+        assertFalse(Files.exists(outFile));
     }
 
     @Test
@@ -66,7 +70,7 @@ class ExportCommandTest {
 
         Path outFile = tempDir.resolve("special.csv");
         ExportCommand cmd = new ExportCommand(outFile.toString());
-        cmd.execute(tm, ui);
+        cmd.execute(tm, uiWith(""));
 
         List<String> lines = Files.readAllLines(outFile);
         assertEquals(2, lines.size());
@@ -79,7 +83,7 @@ class ExportCommandTest {
                 LocalDate.of(2026, 1, 1), "Test"));
 
         ExportCommand cmd = new ExportCommand("");
-        cmd.execute(tm, ui);
+        cmd.execute(tm, uiWith(""));
 
         String expectedName = "transactions_"
                 + LocalDate.now().format(DateTimeFormatter.ISO_LOCAL_DATE) + ".csv";
@@ -89,6 +93,43 @@ class ExportCommandTest {
         } finally {
             Files.deleteIfExists(created);
         }
+    }
+
+    @Test
+    void execute_dataDirectoryInPath_throwsException() {
+        Path outFile = tempDir.resolve("data").resolve("backup.csv");
+        ExportCommand cmd = new ExportCommand(outFile.toString());
+        assertThrows(RLADException.class, () -> cmd.execute(tm, uiWith("")));
+    }
+
+    @Test
+    void execute_missingParentDirectory_userConfirms_createsDirectoryAndFile() throws Exception {
+        tm.addTransaction(new Transaction("debit", "food", 10.00,
+                LocalDate.of(2026, 1, 1), "Test"));
+
+        Path newDir = tempDir.resolve("exports");
+        Path outFile = newDir.resolve("backup.csv");
+        assertFalse(Files.isDirectory(newDir));
+
+        ExportCommand cmd = new ExportCommand(outFile.toString());
+        cmd.execute(tm, uiWith("y\n"));
+
+        assertTrue(Files.isDirectory(newDir));
+        assertTrue(Files.exists(outFile));
+    }
+
+    @Test
+    void execute_missingParentDirectory_userDeclines_cancelsExport() throws Exception {
+        tm.addTransaction(new Transaction("debit", "food", 10.00,
+                LocalDate.of(2026, 1, 1), "Test"));
+
+        Path newDir = tempDir.resolve("exports");
+        Path outFile = newDir.resolve("backup.csv");
+
+        ExportCommand cmd = new ExportCommand(outFile.toString());
+        cmd.execute(tm, uiWith("n\n"));
+
+        assertFalse(Files.exists(outFile));
     }
 
     @Test

--- a/src/test/java/seedu/RLAD/command/ExportCommandTest.java
+++ b/src/test/java/seedu/RLAD/command/ExportCommandTest.java
@@ -11,7 +11,9 @@ import seedu.RLAD.exception.RLADException;
 import java.io.ByteArrayInputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -40,30 +42,22 @@ class ExportCommandTest {
         tm.addTransaction(new Transaction("debit", "transport", 3.50,
                 LocalDate.of(2026, 3, 16), "Bus"));
 
-        String file = tempDir.resolve("out.csv").toString();
-        ExportCommand cmd = new ExportCommand("--file out.csv --path " + tempDir);
+        Path outFile = tempDir.resolve("out.csv");
+        ExportCommand cmd = new ExportCommand(outFile.toString());
         cmd.execute(tm, ui);
 
-        Path filePath = tempDir.resolve("out.csv");
-        assertTrue(Files.exists(filePath));
-        List<String> lines = Files.readAllLines(filePath);
+        assertTrue(Files.exists(outFile));
+        List<String> lines = Files.readAllLines(outFile);
         assertEquals(3, lines.size());
         assertEquals("HashID,Type,Category,Amount,Date,Description", lines.get(0));
     }
 
     @Test
     void execute_emptyTransactions_noFileCreated() throws RLADException {
-        ExportCommand cmd = new ExportCommand("--file out.csv --path " + tempDir);
+        Path outFile = tempDir.resolve("out.csv");
+        ExportCommand cmd = new ExportCommand(outFile.toString());
         cmd.execute(tm, ui);
-        assertTrue(!Files.exists(tempDir.resolve("out.csv")));
-    }
-
-    @Test
-    void execute_invalidPath_throwsException() {
-        tm.addTransaction(new Transaction("credit", "food", 50.00,
-                LocalDate.of(2026, 3, 15), "Test"));
-        ExportCommand cmd = new ExportCommand("--path /nonexistent/dir/xyz");
-        assertThrows(RLADException.class, () -> cmd.execute(tm, ui));
+        assertTrue(!Files.exists(outFile));
     }
 
     @Test
@@ -71,33 +65,36 @@ class ExportCommandTest {
         tm.addTransaction(new Transaction("credit", "food", 25.00,
                 LocalDate.of(2026, 1, 1), "Meal, \"fancy\" place"));
 
-        ExportCommand cmd = new ExportCommand("--file special.csv --path " + tempDir);
+        Path outFile = tempDir.resolve("special.csv");
+        ExportCommand cmd = new ExportCommand(outFile.toString());
         cmd.execute(tm, ui);
 
-        List<String> lines = Files.readAllLines(tempDir.resolve("special.csv"));
+        List<String> lines = Files.readAllLines(outFile);
         assertEquals(2, lines.size());
         assertTrue(lines.get(1).contains("\"Meal, \"\"fancy\"\" place\""));
     }
 
     @Test
+    void execute_defaultFilename_usesDateBasedName() throws Exception {
+        tm.addTransaction(new Transaction("credit", "food", 10.00,
+                LocalDate.of(2026, 1, 1), "Test"));
+
+        ExportCommand cmd = new ExportCommand("");
+        cmd.execute(tm, ui);
+
+        String expectedName = "transactions_"
+                + LocalDate.now().format(DateTimeFormatter.ISO_LOCAL_DATE) + ".csv";
+        Path created = Paths.get(expectedName);
+        try {
+            assertTrue(Files.exists(created));
+        } finally {
+            Files.deleteIfExists(created);
+        }
+    }
+
+    @Test
     void hasValidArgs_always_returnsTrue() {
         assertEquals(true, new ExportCommand("").hasValidArgs());
-        assertEquals(true, new ExportCommand("--file test.csv").hasValidArgs());
-    }
-
-    @Test
-    void execute_emptyFileFlag_throwsException() {
-        tm.addTransaction(new Transaction("credit", "food", 50.00,
-                LocalDate.of(2026, 3, 15), "Test"));
-        ExportCommand cmd = new ExportCommand("--file");
-        assertThrows(RLADException.class, () -> cmd.execute(tm, ui));
-    }
-
-    @Test
-    void execute_emptyPathFlag_throwsException() {
-        tm.addTransaction(new Transaction("credit", "food", 50.00,
-                LocalDate.of(2026, 3, 15), "Test"));
-        ExportCommand cmd = new ExportCommand("--file out.csv --path");
-        assertThrows(RLADException.class, () -> cmd.execute(tm, ui));
+        assertEquals(true, new ExportCommand("backup.csv").hasValidArgs());
     }
 }

--- a/src/test/java/seedu/RLAD/command/ExportCommandTest.java
+++ b/src/test/java/seedu/RLAD/command/ExportCommandTest.java
@@ -103,7 +103,7 @@ class ExportCommandTest {
     }
 
     @Test
-    void execute_missingParentDirectory_userConfirms_createsDirectoryAndFile() throws Exception {
+    void execute_missingDirUserConfirms_createsDirectoryAndFile() throws Exception {
         tm.addTransaction(new Transaction("debit", "food", 10.00,
                 LocalDate.of(2026, 1, 1), "Test"));
 
@@ -119,7 +119,7 @@ class ExportCommandTest {
     }
 
     @Test
-    void execute_missingParentDirectory_userDeclines_cancelsExport() throws Exception {
+    void execute_missingDirUserDeclines_cancelsExport() throws Exception {
         tm.addTransaction(new Transaction("debit", "food", 10.00,
                 LocalDate.of(2026, 1, 1), "Test"));
 

--- a/src/test/java/seedu/RLAD/command/ExportCommandTest.java
+++ b/src/test/java/seedu/RLAD/command/ExportCommandTest.java
@@ -17,7 +17,6 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ExportCommandTest {

--- a/src/test/java/seedu/RLAD/command/ImportCommandTest.java
+++ b/src/test/java/seedu/RLAD/command/ImportCommandTest.java
@@ -48,7 +48,7 @@ class ImportCommandTest {
     void execute_validFile_importsTransactions() throws Exception {
         Path file = createValidCsv("valid.csv");
         Ui ui = createUiWithInput("");
-        ImportCommand cmd = new ImportCommand("--file " + file);
+        ImportCommand cmd = new ImportCommand(file.toString());
         cmd.execute(tm, ui);
         assertEquals(2, tm.getTransactionCount());
     }
@@ -61,7 +61,7 @@ class ImportCommandTest {
 
         Path file = createValidCsv("merge.csv");
         Ui ui = createUiWithInput("");
-        ImportCommand cmd = new ImportCommand("--file " + file + " --merge");
+        ImportCommand cmd = new ImportCommand(file + " merge");
         cmd.execute(tm, ui);
         assertEquals(3, tm.getTransactionCount());
     }
@@ -73,7 +73,7 @@ class ImportCommandTest {
 
         Path file = createValidCsv("replace.csv");
         Ui ui = createUiWithInput("CONFIRM\n");
-        ImportCommand cmd = new ImportCommand("--file " + file);
+        ImportCommand cmd = new ImportCommand(file.toString());
         cmd.execute(tm, ui);
         assertEquals(2, tm.getTransactionCount());
     }
@@ -85,7 +85,7 @@ class ImportCommandTest {
 
         Path file = createValidCsv("cancel.csv");
         Ui ui = createUiWithInput("no\n");
-        ImportCommand cmd = new ImportCommand("--file " + file);
+        ImportCommand cmd = new ImportCommand(file.toString());
         cmd.execute(tm, ui);
         assertEquals(1, tm.getTransactionCount());
     }
@@ -93,7 +93,7 @@ class ImportCommandTest {
     @Test
     void execute_fileNotFound_throwsException() {
         Ui ui = createUiWithInput("");
-        ImportCommand cmd = new ImportCommand("--file nonexistent.csv");
+        ImportCommand cmd = new ImportCommand("nonexistent.csv");
         assertThrows(RLADException.class, () -> cmd.execute(tm, ui));
     }
 
@@ -106,7 +106,7 @@ class ImportCommandTest {
         Files.writeString(file, content);
 
         Ui ui = createUiWithInput("");
-        ImportCommand cmd = new ImportCommand("--file " + file);
+        ImportCommand cmd = new ImportCommand(file.toString());
         cmd.execute(tm, ui);
         assertEquals(1, tm.getTransactionCount());
     }
@@ -119,30 +119,30 @@ class ImportCommandTest {
         Files.writeString(file, content);
 
         Ui ui = createUiWithInput("");
-        ImportCommand cmd = new ImportCommand("--file " + file);
+        ImportCommand cmd = new ImportCommand(file.toString());
         assertThrows(RLADException.class, () -> cmd.execute(tm, ui));
     }
 
     @Test
     void hasValidArgs_alwaysTrue() {
-        assertEquals(true, new ImportCommand("--file test.csv").hasValidArgs());
-        assertEquals(true, new ImportCommand("--merge").hasValidArgs());
+        assertEquals(true, new ImportCommand("backup.csv").hasValidArgs());
+        assertEquals(true, new ImportCommand("backup.csv merge").hasValidArgs());
         assertEquals(true, new ImportCommand("").hasValidArgs());
     }
 
     @Test
-    void execute_missingFileFlag_throwsException() {
+    void execute_missingFilename_throwsException() {
         Ui ui = createUiWithInput("");
-        ImportCommand cmd = new ImportCommand("--merge");
+        ImportCommand cmd = new ImportCommand("");
         RLADException ex = assertThrows(RLADException.class, () -> cmd.execute(tm, ui));
-        assertTrue(ex.getMessage().contains("--file is required"));
+        assertTrue(ex.getMessage().contains("Usage: import"));
     }
 
     @Test
-    void execute_emptyFileFlag_throwsException() {
+    void execute_onlyMergeKeyword_throwsException() {
         Ui ui = createUiWithInput("");
-        ImportCommand cmd = new ImportCommand("--file");
+        ImportCommand cmd = new ImportCommand("merge");
         RLADException ex = assertThrows(RLADException.class, () -> cmd.execute(tm, ui));
-        assertTrue(ex.getMessage().contains("--file is required"));
+        assertTrue(ex.getMessage().contains("Usage: import"));
     }
 }


### PR DESCRIPTION
## Summary
- `export [filename]` and `import <filename> [merge]` now parse positional args instead of requiring `--file`/`--merge` flags
- `export backup.csv` creates `backup.csv`
- `import backup.csv` and `import backup.csv merge` now work correctly
- Updated tests to use UG-compliant syntax; added tests for missing-filename error

Fixes #103