### PR TITLE
Fix search to accept positional keyword arg per UG

### DIFF
--- a/src/main/java/seedu/RLAD/command/SearchCommand.java
+++ b/src/main/java/seedu/RLAD/command/SearchCommand.java
@@ -6,7 +6,6 @@ import seedu.RLAD.Ui;
 import seedu.RLAD.exception.RLADException;
 
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 public class SearchCommand extends Command {
@@ -18,9 +17,7 @@ public class SearchCommand extends Command {
     }
 
     private String parseKeyword() {
-        Map<String, String> flags = FilterCommand.parseFlags(rawArgs);
-        String keyword = flags.get("keyword");
-        return (keyword != null && !keyword.isEmpty()) ? keyword : null;
+        return (rawArgs != null && !rawArgs.trim().isEmpty()) ? rawArgs.trim() : null;
     }
 
     private boolean matchesKeyword(Transaction t, String keyword) {
@@ -77,6 +74,6 @@ public class SearchCommand extends Command {
 
     @Override
     public boolean hasValidArgs() {
-        return rawArgs != null && rawArgs.contains("--keyword") && parseKeyword() != null;
+        return rawArgs != null && !rawArgs.trim().isEmpty();
     }
 }

--- a/src/test/java/seedu/RLAD/command/SearchCommandTest.java
+++ b/src/test/java/seedu/RLAD/command/SearchCommandTest.java
@@ -40,43 +40,43 @@ class SearchCommandTest {
 
     @Test
     void execute_searchByDescription_findsMatch() throws Exception {
-        new SearchCommand("--keyword lunch").execute(manager, ui);
+        new SearchCommand("lunch").execute(manager, ui);
         assertTrue(output.stream().anyMatch(s -> s.contains("Hawker lunch")));
     }
 
     @Test
     void execute_searchByCategory_findsMatch() throws Exception {
-        new SearchCommand("--keyword food").execute(manager, ui);
+        new SearchCommand("food").execute(manager, ui);
         assertTrue(output.stream().anyMatch(s -> s.contains("food") || s.contains("FOOD")));
     }
 
     @Test
     void execute_searchByAmount_findsMatch() throws Exception {
-        new SearchCommand("--keyword 50.00").execute(manager, ui);
+        new SearchCommand("50.00").execute(manager, ui);
         assertTrue(output.stream().anyMatch(s -> s.contains("$50.00")));
     }
 
     @Test
     void execute_noMatches_showsEmptyMessage() throws Exception {
-        new SearchCommand("--keyword xyz999").execute(manager, ui);
+        new SearchCommand("xyz999").execute(manager, ui);
         assertTrue(output.get(0).contains("No transactions found matching"));
     }
 
     @Test
     void execute_searchByPartialDescription_findsMatch() throws Exception {
-        new SearchCommand("--keyword MRT").execute(manager, ui);
+        new SearchCommand("MRT").execute(manager, ui);
         assertTrue(output.stream().anyMatch(s -> s.contains("MRT")));
     }
 
     @Test
     void execute_caseInsensitive_findsMatch() throws Exception {
-        new SearchCommand("--keyword SALARY").execute(manager, ui);
+        new SearchCommand("SALARY").execute(manager, ui);
         assertTrue(output.stream().anyMatch(s -> s.contains("salary") || s.contains("SALARY")));
     }
 
     @Test
     void hasValidArgs_withKeyword_returnsTrue() {
-        assertTrue(new SearchCommand("--keyword food").hasValidArgs());
+        assertTrue(new SearchCommand("food").hasValidArgs());
     }
 
     @Test
@@ -87,7 +87,7 @@ class SearchCommandTest {
 
     @Test
     void execute_showsResultCount() throws Exception {
-        new SearchCommand("--keyword food").execute(manager, ui);
+        new SearchCommand("food").execute(manager, ui);
         assertTrue(output.stream().anyMatch(s -> s.contains("transaction(s) found")));
     }
 }


### PR DESCRIPTION
## Summary
- `search <keyword>` now works as documented — `search chicken` correctly finds matching transactions
- Removed the undocumented `--keyword` flag requirement from `SearchCommand`
- `help search` already showed the correct syntax; the command itself now matches
- Updated tests to use positional syntax

Fixes #84