### PR TITLE
Fix list space-after-colon parsing and clarify multi-category OR logic in UG

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -544,10 +544,12 @@ list from:last-month to:this-month type:debit    # Last month's expenses
 
 ### 5.3 Multi-Category Filtering
 
-To filter by more than one category simultaneously, provide a comma-separated list with no spaces:
+To filter by more than one category simultaneously, provide a comma-separated list with no spaces.
+The comma acts as **OR** — a transaction matches if its category is any one of the listed values.
+This is different from combining separate filters (e.g. `type:debit cat:food`), where each filter uses AND logic.
 
 ```
-list cat:food,transport             # Show food AND transport transactions
+list cat:food,transport             # Show food OR transport transactions
 summarize cat:food,transport,health # Summary across three categories
 ```
 

--- a/src/main/java/seedu/RLAD/command/FilterCommand.java
+++ b/src/main/java/seedu/RLAD/command/FilterCommand.java
@@ -279,6 +279,8 @@ public class FilterCommand extends Command {
      */
     public static List<Transaction> applyColonFilters(List<Transaction> transactions, String filterStr)
             throws RLADException {
+        // Normalize "key: value" to "key:value" so spaces after colons are accepted
+        filterStr = filterStr.replaceAll("([a-zA-Z]+):\\s+", "$1:");
         String[] parts = filterStr.split("\\s+");
         List<Transaction> result = new ArrayList<>(transactions);
 


### PR DESCRIPTION
## Summary
- `list min: 50 max: 200` (space after colon) now works correctly — parser normalises `key: value` to `key:value` before splitting (fixes #125)
- UG section 5.3: `cat:food,transport` now correctly documented as OR match, not AND (fixes #126)
- `list cat:none` NPE was already resolved by PR #133 (closes #90)