### PR TITLE
Fix budget persistence and pipe characters in autosave causing data loss

### DIFF
--- a/src/main/java/seedu/RLAD/RLAD.java
+++ b/src/main/java/seedu/RLAD/RLAD.java
@@ -22,6 +22,7 @@ public class RLAD {
         this.budgetManager.setUi(this.ui);
         this.transactions.setBudgetManager(budgetManager);
         this.transactions.loadFromAutoSave();
+        this.budgetManager.load();
 
         // daddy logger takes care of all the loggers from here
         Logger packageLogger = Logger.getLogger("seedu.RLAD");

--- a/src/main/java/seedu/RLAD/budget/BudgetManager.java
+++ b/src/main/java/seedu/RLAD/budget/BudgetManager.java
@@ -34,7 +34,7 @@ public class BudgetManager {
 
     private static final Logger logger = Logger.getLogger(BudgetManager.class.getName());
     private static final String SAVE_DIR = "data";
-    private static final String SAVE_FILE = SAVE_DIR + File.separator + "budget.csv";
+    private static final String SAVE_FILE = SAVE_DIR + File.separator + "rlad_budget.csv";
     private static final String CSV_HEADER = "Month,CategoryCode,Amount";
 
     private final Map<String, Set<Integer>> notifiedThresholds = new HashMap<>();
@@ -477,7 +477,7 @@ public class BudgetManager {
     }
 
     /**
-     * Loads budget entries from data/budget.csv on startup.
+     * Loads budget entries from data/rlad_budget.csv on startup.
      * Uses CsvStorageManager.parseCsvLine() so quoted commas are handled correctly.
      * Silently skips the header and any malformed lines.
      */

--- a/src/main/java/seedu/RLAD/budget/BudgetManager.java
+++ b/src/main/java/seedu/RLAD/budget/BudgetManager.java
@@ -5,6 +5,8 @@ import seedu.RLAD.TransactionManager;
 import seedu.RLAD.exception.RLADException;
 import seedu.RLAD.Ui;
 
+import seedu.RLAD.storage.CsvStorageManager;
+
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
@@ -32,7 +34,8 @@ public class BudgetManager {
 
     private static final Logger logger = Logger.getLogger(BudgetManager.class.getName());
     private static final String SAVE_DIR = "data";
-    private static final String SAVE_FILE = SAVE_DIR + File.separator + "budget.txt";
+    private static final String SAVE_FILE = SAVE_DIR + File.separator + "budget.csv";
+    private static final String CSV_HEADER = "Month,CategoryCode,Amount";
 
     private final Map<String, Set<Integer>> notifiedThresholds = new HashMap<>();
     private final Map<YearMonth, MonthlyBudget> budgets;
@@ -441,8 +444,9 @@ public class BudgetManager {
         }
     }
     /**
-     * Saves all budget entries to data/budget.txt.
-     * Format per line: YYYY-MM|CATEGORY_CODE|AMOUNT
+     * Saves all budget entries to data/budget.csv.
+     * Uses CSV format with header: Month,CategoryCode,Amount
+     * Fields are escaped via CsvStorageManager so commas in future fields are handled correctly.
      */
     public void save() {
         try {
@@ -451,12 +455,18 @@ public class BudgetManager {
                 dir.mkdirs();
             }
             BufferedWriter writer = new BufferedWriter(new FileWriter(SAVE_FILE));
+            writer.write(CSV_HEADER);
+            writer.newLine();
             for (Map.Entry<YearMonth, MonthlyBudget> entry : budgets.entrySet()) {
                 YearMonth month = entry.getKey();
                 for (Map.Entry<BudgetCategory, Double> catEntry
                         : entry.getValue().getCategoryBudgets().entrySet()) {
-                    writer.write(month + "|" + catEntry.getKey().getCode()
-                            + "|" + catEntry.getValue());
+                    String line = CsvStorageManager.escapeCsvField(month.toString())
+                            + "," + CsvStorageManager.escapeCsvField(
+                                    String.valueOf(catEntry.getKey().getCode()))
+                            + "," + CsvStorageManager.escapeCsvField(
+                                    String.format("%.2f", catEntry.getValue()));
+                    writer.write(line);
                     writer.newLine();
                 }
             }
@@ -467,8 +477,9 @@ public class BudgetManager {
     }
 
     /**
-     * Loads budget entries from data/budget.txt on startup.
-     * Silently skips malformed lines.
+     * Loads budget entries from data/budget.csv on startup.
+     * Uses CsvStorageManager.parseCsvLine() so quoted commas are handled correctly.
+     * Silently skips the header and any malformed lines.
      */
     public void load() {
         File file = new File(SAVE_FILE);
@@ -477,14 +488,18 @@ public class BudgetManager {
         }
         try {
             BufferedReader reader = new BufferedReader(new FileReader(file));
-            String line;
+            String line = reader.readLine(); // skip header
             while ((line = reader.readLine()) != null) {
-                String[] parts = line.split("\\|", 3);
+                if (line.trim().isEmpty()) {
+                    continue;
+                }
+                String[] parts = CsvStorageManager.parseCsvLine(line);
                 if (parts.length != 3) {
+                    logger.warning("Skipping invalid budget line: " + line);
                     continue;
                 }
                 try {
-                    YearMonth month = YearMonth.parse(parts[0]);
+                    YearMonth month = YearMonth.parse(parts[0].trim());
                     int code = Integer.parseInt(parts[1].trim());
                     double amount = Double.parseDouble(parts[2].trim());
                     BudgetCategory category = BudgetCategory.fromCode(code);

--- a/src/main/java/seedu/RLAD/budget/BudgetManager.java
+++ b/src/main/java/seedu/RLAD/budget/BudgetManager.java
@@ -5,14 +5,21 @@ import seedu.RLAD.TransactionManager;
 import seedu.RLAD.exception.RLADException;
 import seedu.RLAD.Ui;
 
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
 import java.time.YearMonth;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.Arrays;
-import java.util.List;
+import java.util.logging.Logger;
 
 /**
  * Manages all monthly budgets and handles progress calculations.
@@ -22,6 +29,10 @@ public class BudgetManager {
     private static final double THRESHOLD_80 = 0.80;
     private static final double THRESHOLD_90 = 0.90;
     private static final double THRESHOLD_100 = 1.00;
+
+    private static final Logger logger = Logger.getLogger(BudgetManager.class.getName());
+    private static final String SAVE_DIR = "data";
+    private static final String SAVE_FILE = SAVE_DIR + File.separator + "budget.txt";
 
     private final Map<String, Set<Integer>> notifiedThresholds = new HashMap<>();
     private final Map<YearMonth, MonthlyBudget> budgets;
@@ -69,6 +80,7 @@ public class BudgetManager {
 
         // Update total income for the month
         updateTotalIncome(month);
+        save();
     }
 
     /**
@@ -83,6 +95,7 @@ public class BudgetManager {
         MonthlyBudget budget = getBudget(month)
                 .orElseThrow(() -> new RLADException("No budget found for " + month));
         budget.editBudget(category, amount);
+        save();
     }
 
     /**
@@ -101,6 +114,7 @@ public class BudgetManager {
         if (budget.getBudgetedCategoryCount() == 0) {
             budgets.remove(month);
         }
+        save();
     }
 
     /**
@@ -426,6 +440,65 @@ public class BudgetManager {
             ui.showResult(message);
         }
     }
+    /**
+     * Saves all budget entries to data/budget.txt.
+     * Format per line: YYYY-MM|CATEGORY_CODE|AMOUNT
+     */
+    public void save() {
+        try {
+            File dir = new File(SAVE_DIR);
+            if (!dir.exists()) {
+                dir.mkdirs();
+            }
+            BufferedWriter writer = new BufferedWriter(new FileWriter(SAVE_FILE));
+            for (Map.Entry<YearMonth, MonthlyBudget> entry : budgets.entrySet()) {
+                YearMonth month = entry.getKey();
+                for (Map.Entry<BudgetCategory, Double> catEntry
+                        : entry.getValue().getCategoryBudgets().entrySet()) {
+                    writer.write(month + "|" + catEntry.getKey().getCode()
+                            + "|" + catEntry.getValue());
+                    writer.newLine();
+                }
+            }
+            writer.close();
+        } catch (IOException e) {
+            logger.warning("Budget save failed: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Loads budget entries from data/budget.txt on startup.
+     * Silently skips malformed lines.
+     */
+    public void load() {
+        File file = new File(SAVE_FILE);
+        if (!file.exists()) {
+            return;
+        }
+        try {
+            BufferedReader reader = new BufferedReader(new FileReader(file));
+            String line;
+            while ((line = reader.readLine()) != null) {
+                String[] parts = line.split("\\|", 3);
+                if (parts.length != 3) {
+                    continue;
+                }
+                try {
+                    YearMonth month = YearMonth.parse(parts[0]);
+                    int code = Integer.parseInt(parts[1].trim());
+                    double amount = Double.parseDouble(parts[2].trim());
+                    BudgetCategory category = BudgetCategory.fromCode(code);
+                    getOrCreateBudget(month).setBudget(category, amount);
+                } catch (Exception e) {
+                    logger.warning("Skipping invalid budget line: " + line);
+                }
+            }
+            reader.close();
+        } catch (IOException e) {
+            logger.warning("Budget load failed: " + e.getMessage());
+        }
+    }
+
     public String getYearlySummary(int year) {
         List<String> monthNames = Arrays.asList(
                 "January", "February", "March", "April",

--- a/src/main/java/seedu/RLAD/storage/AutoSaveManager.java
+++ b/src/main/java/seedu/RLAD/storage/AutoSaveManager.java
@@ -1,12 +1,11 @@
 package seedu.RLAD.storage;
 
 import seedu.RLAD.Transaction;
+import seedu.RLAD.exception.RLADException;
 
 import java.io.BufferedReader;
-import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileReader;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -15,24 +14,28 @@ import java.util.logging.Logger;
 /**
  * Handles automatic saving and loading of transactions to a local file.
  * This is for crash recovery only, not for user-facing export/import.
- * Data is stored in a simple pipe-delimited text format.
+ * Data is stored in CSV format so that pipes and commas in fields are handled safely.
+ * Saving reuses CsvStorageManager.exportToCsv(); loading reads the same format but
+ * preserves existing HashIDs (unlike the user-facing import which generates new ones).
  */
 public class AutoSaveManager {
 
     private static final Logger logger = Logger.getLogger(AutoSaveManager.class.getName());
     private static final String SAVE_DIR = "data";
-    private static final String SAVE_FILE = "rlad.txt";
-    private static final String SEPARATOR = "|";
+    private static final String SAVE_FILE = "rlad.csv";
+    private static final String LEGACY_SAVE_FILE = "rlad.txt";
 
     private final String filePath;
+    private final String legacyFilePath;
 
     public AutoSaveManager() {
         this.filePath = SAVE_DIR + File.separator + SAVE_FILE;
+        this.legacyFilePath = SAVE_DIR + File.separator + LEGACY_SAVE_FILE;
     }
 
     /**
-     * Saves all transactions to the autosave file.
-     * Overwrites the entire file each time.
+     * Saves all transactions to the autosave CSV file.
+     * Delegates to CsvStorageManager.exportToCsv() which handles all escaping.
      *
      * @param transactions the list of transactions to save
      */
@@ -42,45 +45,49 @@ public class AutoSaveManager {
             if (!dir.exists()) {
                 dir.mkdirs();
             }
-
-            BufferedWriter writer = new BufferedWriter(new FileWriter(filePath));
-            for (Transaction t : transactions) {
-                String line = t.getHashId() + SEPARATOR
-                        + t.getType() + SEPARATOR
-                        + (t.getCategory() != null ? t.getCategory() : "") + SEPARATOR
-                        + t.getAmount() + SEPARATOR
-                        + t.getDate().toString() + SEPARATOR
-                        + t.getDescription();
-                writer.write(line);
-                writer.newLine();
-            }
-            writer.close();
+            CsvStorageManager.exportToCsv(transactions, filePath);
             logger.fine("Autosaved " + transactions.size() + " transactions.");
-        } catch (IOException e) {
+        } catch (RLADException e) {
             logger.warning("Autosave failed: " + e.getMessage());
         }
     }
 
     /**
-     * Loads transactions from the autosave file.
-     * Returns an empty list if the file does not exist or is unreadable.
+     * Loads transactions from the autosave file, preserving their original HashIDs.
+     * If the new CSV file does not exist but the legacy pipe-delimited file does,
+     * migrates the data automatically.
+     * Returns an empty list if no file exists or the file is unreadable.
      *
      * @return list of loaded transactions
      */
     public ArrayList<Transaction> load() {
+        File csvFile = new File(filePath);
+        File legacyFile = new File(legacyFilePath);
+
+        if (!csvFile.exists() && legacyFile.exists()) {
+            ArrayList<Transaction> migrated = loadLegacy(legacyFile);
+            save(migrated);
+            legacyFile.delete();
+            logger.fine("Migrated " + migrated.size() + " transactions from legacy rlad.txt to rlad.csv.");
+            return migrated;
+        }
+
         ArrayList<Transaction> loaded = new ArrayList<>();
-        File file = new File(filePath);
-        if (!file.exists()) {
+        if (!csvFile.exists()) {
             return loaded;
         }
 
         try {
-            BufferedReader reader = new BufferedReader(new FileReader(file));
+            BufferedReader reader = new BufferedReader(new FileReader(csvFile));
+            reader.readLine(); // skip header
             String line;
-            int lineNum = 0;
+            int lineNum = 1;
             while ((line = reader.readLine()) != null) {
                 lineNum++;
-                Transaction t = parseLine(line, lineNum);
+                if (line.trim().isEmpty()) {
+                    continue;
+                }
+                Transaction t = parseCsvLine(line, lineNum);
                 if (t != null) {
                     loaded.add(t);
                 }
@@ -94,11 +101,13 @@ public class AutoSaveManager {
     }
 
     /**
-     * Parses a single line from the autosave file into a Transaction.
+     * Parses a single CSV line from the autosave file into a Transaction,
+     * preserving the original HashID.
      * Returns null if the line is malformed.
      */
-    private Transaction parseLine(String line, int lineNum) {
-        String[] parts = line.split("\\|", 6);
+    private Transaction parseCsvLine(String line, int lineNum) {
+        // columns: HashID(0), Type(1), Category(2), Amount(3), Date(4), Description(5)
+        String[] parts = CsvStorageManager.parseCsvLine(line);
         if (parts.length < 5) {
             logger.warning("Skipping malformed autosave line " + lineNum);
             return null;
@@ -109,7 +118,7 @@ public class AutoSaveManager {
             String category = parts[2].isEmpty() ? null : parts[2];
             double amount = Double.parseDouble(parts[3]);
             LocalDate date = LocalDate.parse(parts[4]);
-            String description = parts.length > 5 ? parts[5] : "";
+            String description = parts.length > 5 && !parts[5].isEmpty() ? parts[5] : null;
 
             Transaction t = new Transaction(type, category, amount, date, description);
             t.setHashId(hashId);
@@ -118,5 +127,44 @@ public class AutoSaveManager {
             logger.warning("Skipping invalid autosave line " + lineNum + ": " + e.getMessage());
             return null;
         }
+    }
+
+    /**
+     * Loads transactions from the legacy pipe-delimited rlad.txt file.
+     * Used only during one-time migration to the new CSV format.
+     */
+    private ArrayList<Transaction> loadLegacy(File file) {
+        ArrayList<Transaction> loaded = new ArrayList<>();
+        try {
+            BufferedReader reader = new BufferedReader(new FileReader(file));
+            String line;
+            int lineNum = 0;
+            while ((line = reader.readLine()) != null) {
+                lineNum++;
+                String[] parts = line.split("\\|", 6);
+                if (parts.length < 5) {
+                    logger.warning("Skipping malformed legacy line " + lineNum);
+                    continue;
+                }
+                try {
+                    String hashId = parts[0];
+                    String type = parts[1];
+                    String category = parts[2].isEmpty() ? null : parts[2];
+                    double amount = Double.parseDouble(parts[3]);
+                    LocalDate date = LocalDate.parse(parts[4]);
+                    String description = parts.length > 5 && !parts[5].isEmpty() ? parts[5] : null;
+
+                    Transaction t = new Transaction(type, category, amount, date, description);
+                    t.setHashId(hashId);
+                    loaded.add(t);
+                } catch (Exception e) {
+                    logger.warning("Skipping invalid legacy line " + lineNum + ": " + e.getMessage());
+                }
+            }
+            reader.close();
+        } catch (IOException e) {
+            logger.warning("Failed to read legacy autosave: " + e.getMessage());
+        }
+        return loaded;
     }
 }

--- a/src/main/java/seedu/RLAD/storage/CsvStorageManager.java
+++ b/src/main/java/seedu/RLAD/storage/CsvStorageManager.java
@@ -185,7 +185,7 @@ public class CsvStorageManager {
      * @param field the field value to escape
      * @return the escaped field value
      */
-    static String escapeCsvField(String field) {
+    public static String escapeCsvField(String field) {
         if (field == null) {
             return "";
         }
@@ -202,7 +202,7 @@ public class CsvStorageManager {
      * @param line the CSV line to parse
      * @return array of field values
      */
-    static String[] parseCsvLine(String line) {
+    public static String[] parseCsvLine(String line) {
         ArrayList<String> fields = new ArrayList<>();
         StringBuilder current = new StringBuilder();
         boolean inQuotes = false;

--- a/src/test/java/seedu/RLAD/storage/AutoSaveManagerTest.java
+++ b/src/test/java/seedu/RLAD/storage/AutoSaveManagerTest.java
@@ -15,7 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class AutoSaveManagerTest {
 
     private AutoSaveManager autoSaveManager;
-    private final String saveFile = "data" + File.separator + "rlad.txt";
+    private final String saveFile = "data" + File.separator + "rlad.csv";
 
     @BeforeEach
     void setUp() {
@@ -105,7 +105,7 @@ class AutoSaveManagerTest {
 
         ArrayList<Transaction> loaded = autoSaveManager.load();
         assertEquals(1, loaded.size());
-        // Description is the last field, so pipes within it are preserved
+        // CSV format correctly escapes pipe characters in any field
         assertEquals("lunch|dinner", loaded.get(0).getDescription());
     }
 }


### PR DESCRIPTION
## Summary
- Budget entries now persist to `data/rlad_budget.csv` across app restarts
- Autosave switched from pipe-delimited `rlad.txt` to CSV `rlad.csv`, fixing silent data loss when pipe characters appear in category or description fields
- Reuses `CsvStorageManager.exportToCsv()` for saving; load preserves original HashIDs
- Existing `rlad.txt` files are automatically migrated to `rlad.csv` on first launch

Fixes #76, Fixes #99

## Test plan
- [ ] `budget set 2026-04 1 500` → exit → relaunch → `budget view` shows entry
- [ ] `budget delete 2026-04 1` → exit → relaunch → entry is gone
- [ ] `add debit 15.50 2026-03-05 food|drinks "Lunch"` → exit → relaunch → `list` shows transaction intact
- [ ] `add debit 10 2026-03-05 "food,drinks" "Lunch"` → exit → relaunch → transaction intact