### PR TITLE
Fix: import/export commands now accept positional arguments per UG

### DIFF
--- a/src/main/java/seedu/RLAD/command/ExportCommand.java
+++ b/src/main/java/seedu/RLAD/command/ExportCommand.java
@@ -12,7 +12,6 @@ import java.nio.file.Paths;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.Map;
 
 /**
  * Exports all transactions to a CSV file.
@@ -30,24 +29,14 @@ public class ExportCommand extends Command {
 
     @Override
     public void execute(TransactionManager transactions, Ui ui) throws RLADException {
-        Map<String, String> flags = FilterCommand.parseFlags(rawArgs);
+        String filename = parseFilename(rawArgs);
 
-        String filename = stripQuotes(flags.getOrDefault("file",
-                "transactions_" + LocalDate.now().format(DateTimeFormatter.ISO_LOCAL_DATE) + ".csv"));
-        if (filename.isBlank()) {
-            throw new RLADException("--file requires a filename. "
-                    + "Example: export --file transactions.csv");
-        }
-
-        String directory = stripQuotes(flags.getOrDefault("path", "."));
-        if (directory.isBlank()) {
-            throw new RLADException("--path requires a directory. "
-                    + "Example: export --path ./data");
-        }
-
-        Path dirPath = Paths.get(directory);
-        if (!Files.isDirectory(dirPath)) {
-            throw new RLADException("Directory does not exist: " + directory);
+        Path filePath = Paths.get(filename);
+        Path dirPath = filePath.getParent();
+        if (dirPath == null) {
+            dirPath = Paths.get(".");
+        } else if (!Files.isDirectory(dirPath)) {
+            throw new RLADException("Directory does not exist: " + dirPath);
         }
 
         ArrayList<Transaction> txns = transactions.getTransactions();
@@ -56,10 +45,21 @@ public class ExportCommand extends Command {
             return;
         }
 
-        String fullPath = dirPath.resolve(filename).toString();
+        String fullPath = filePath.isAbsolute()
+                ? filePath.toString()
+                : dirPath.resolve(filePath.getFileName()).toString();
         CsvStorageManager.exportToCsv(txns, fullPath);
 
         ui.showResult("Exported " + txns.size() + " transactions to: " + fullPath);
+    }
+
+    private static String parseFilename(String rawArgs) {
+        String defaultName = "transactions_"
+                + LocalDate.now().format(DateTimeFormatter.ISO_LOCAL_DATE) + ".csv";
+        if (rawArgs == null || rawArgs.isBlank()) {
+            return defaultName;
+        }
+        return stripQuotes(rawArgs.trim());
     }
 
     private static String stripQuotes(String value) {

--- a/src/main/java/seedu/RLAD/command/ImportCommand.java
+++ b/src/main/java/seedu/RLAD/command/ImportCommand.java
@@ -8,7 +8,6 @@ import seedu.RLAD.storage.CsvStorageManager;
 
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.Map;
 
 /**
  * Imports transactions from a CSV file, either replacing or merging with existing data.
@@ -26,15 +25,23 @@ public class ImportCommand extends Command {
 
     @Override
     public void execute(TransactionManager transactions, Ui ui) throws RLADException {
-        Map<String, String> flags = FilterCommand.parseFlags(rawArgs);
-
-        String filePath = flags.get("file");
-        if (filePath == null || filePath.isBlank()) {
-            throw new RLADException("--file is required for import. "
-                    + "Usage: import --file FILENAME [--merge]");
+        if (rawArgs == null || rawArgs.isBlank()) {
+            throw new RLADException("Filename is required for import. "
+                    + "Usage: import <filename> [merge]");
         }
 
-        boolean mergeMode = flags.containsKey("merge");
+        String[] tokens = rawArgs.trim().split("\\s+");
+        String filePath = stripQuotes(tokens[0]);
+
+        boolean mergeMode = false;
+        for (int i = 1; i < tokens.length; i++) {
+            if (tokens[i].equalsIgnoreCase("merge")) {
+                mergeMode = true;
+            } else {
+                throw new RLADException("Unknown argument: " + tokens[i] + ". "
+                        + "Usage: import <filename> [merge]");
+            }
+        }
 
         if (!Files.exists(Paths.get(filePath))) {
             throw new RLADException("File not found: " + filePath);
@@ -44,7 +51,7 @@ public class ImportCommand extends Command {
             boolean confirmed = ui.askConfirmation(
                     "WARNING: Replace mode will delete all "
                             + transactions.getTransactionCount() + " existing transactions.\n"
-                            + "Use --merge to add to existing data instead.");
+                            + "Use 'merge' to add to existing data instead.");
             if (!confirmed) {
                 ui.showResult("Import cancelled.");
                 return;
@@ -71,6 +78,13 @@ public class ImportCommand extends Command {
 
         ui.showResult("Import complete: " + result.getSuccessCount() + " succeeded, "
                 + result.getFailCount() + " failed.");
+    }
+
+    private static String stripQuotes(String value) {
+        if (value.length() >= 2 && value.startsWith("\"") && value.endsWith("\"")) {
+            return value.substring(1, value.length() - 1);
+        }
+        return value;
     }
 
     @Override

--- a/src/test/java/seedu/RLAD/command/ExportCommandTest.java
+++ b/src/test/java/seedu/RLAD/command/ExportCommandTest.java
@@ -40,29 +40,29 @@ class ExportCommandTest {
         tm.addTransaction(new Transaction("debit", "transport", 3.50,
                 LocalDate.of(2026, 3, 16), "Bus"));
 
-        String file = tempDir.resolve("out.csv").toString();
-        ExportCommand cmd = new ExportCommand("--file out.csv --path " + tempDir);
+        Path target = tempDir.resolve("out.csv");
+        ExportCommand cmd = new ExportCommand(target.toString());
         cmd.execute(tm, ui);
 
-        Path filePath = tempDir.resolve("out.csv");
-        assertTrue(Files.exists(filePath));
-        List<String> lines = Files.readAllLines(filePath);
+        assertTrue(Files.exists(target));
+        List<String> lines = Files.readAllLines(target);
         assertEquals(3, lines.size());
         assertEquals("HashID,Type,Category,Amount,Date,Description", lines.get(0));
     }
 
     @Test
     void execute_emptyTransactions_noFileCreated() throws RLADException {
-        ExportCommand cmd = new ExportCommand("--file out.csv --path " + tempDir);
+        Path target = tempDir.resolve("out.csv");
+        ExportCommand cmd = new ExportCommand(target.toString());
         cmd.execute(tm, ui);
-        assertTrue(!Files.exists(tempDir.resolve("out.csv")));
+        assertTrue(!Files.exists(target));
     }
 
     @Test
     void execute_invalidPath_throwsException() {
         tm.addTransaction(new Transaction("credit", "food", 50.00,
                 LocalDate.of(2026, 3, 15), "Test"));
-        ExportCommand cmd = new ExportCommand("--path /nonexistent/dir/xyz");
+        ExportCommand cmd = new ExportCommand("/nonexistent/dir/xyz/out.csv");
         assertThrows(RLADException.class, () -> cmd.execute(tm, ui));
     }
 
@@ -71,10 +71,11 @@ class ExportCommandTest {
         tm.addTransaction(new Transaction("credit", "food", 25.00,
                 LocalDate.of(2026, 1, 1), "Meal, \"fancy\" place"));
 
-        ExportCommand cmd = new ExportCommand("--file special.csv --path " + tempDir);
+        Path target = tempDir.resolve("special.csv");
+        ExportCommand cmd = new ExportCommand(target.toString());
         cmd.execute(tm, ui);
 
-        List<String> lines = Files.readAllLines(tempDir.resolve("special.csv"));
+        List<String> lines = Files.readAllLines(target);
         assertEquals(2, lines.size());
         assertTrue(lines.get(1).contains("\"Meal, \"\"fancy\"\" place\""));
     }
@@ -82,22 +83,18 @@ class ExportCommandTest {
     @Test
     void hasValidArgs_always_returnsTrue() {
         assertEquals(true, new ExportCommand("").hasValidArgs());
-        assertEquals(true, new ExportCommand("--file test.csv").hasValidArgs());
+        assertEquals(true, new ExportCommand("test.csv").hasValidArgs());
     }
 
     @Test
-    void execute_emptyFileFlag_throwsException() {
+    void execute_absoluteFilename_createsFileAtPath() throws Exception {
         tm.addTransaction(new Transaction("credit", "food", 50.00,
                 LocalDate.of(2026, 3, 15), "Test"));
-        ExportCommand cmd = new ExportCommand("--file");
-        assertThrows(RLADException.class, () -> cmd.execute(tm, ui));
-    }
 
-    @Test
-    void execute_emptyPathFlag_throwsException() {
-        tm.addTransaction(new Transaction("credit", "food", 50.00,
-                LocalDate.of(2026, 3, 15), "Test"));
-        ExportCommand cmd = new ExportCommand("--file out.csv --path");
-        assertThrows(RLADException.class, () -> cmd.execute(tm, ui));
+        Path target = tempDir.resolve("absolute.csv").toAbsolutePath();
+        ExportCommand cmd = new ExportCommand(target.toString());
+        cmd.execute(tm, ui);
+
+        assertTrue(Files.exists(target));
     }
 }

--- a/src/test/java/seedu/RLAD/command/ImportCommandTest.java
+++ b/src/test/java/seedu/RLAD/command/ImportCommandTest.java
@@ -48,7 +48,7 @@ class ImportCommandTest {
     void execute_validFile_importsTransactions() throws Exception {
         Path file = createValidCsv("valid.csv");
         Ui ui = createUiWithInput("");
-        ImportCommand cmd = new ImportCommand("--file " + file);
+        ImportCommand cmd = new ImportCommand(file.toString());
         cmd.execute(tm, ui);
         assertEquals(2, tm.getTransactionCount());
     }
@@ -61,7 +61,7 @@ class ImportCommandTest {
 
         Path file = createValidCsv("merge.csv");
         Ui ui = createUiWithInput("");
-        ImportCommand cmd = new ImportCommand("--file " + file + " --merge");
+        ImportCommand cmd = new ImportCommand(file + " merge");
         cmd.execute(tm, ui);
         assertEquals(3, tm.getTransactionCount());
     }
@@ -73,7 +73,7 @@ class ImportCommandTest {
 
         Path file = createValidCsv("replace.csv");
         Ui ui = createUiWithInput("CONFIRM\n");
-        ImportCommand cmd = new ImportCommand("--file " + file);
+        ImportCommand cmd = new ImportCommand(file.toString());
         cmd.execute(tm, ui);
         assertEquals(2, tm.getTransactionCount());
     }
@@ -85,7 +85,7 @@ class ImportCommandTest {
 
         Path file = createValidCsv("cancel.csv");
         Ui ui = createUiWithInput("no\n");
-        ImportCommand cmd = new ImportCommand("--file " + file);
+        ImportCommand cmd = new ImportCommand(file.toString());
         cmd.execute(tm, ui);
         assertEquals(1, tm.getTransactionCount());
     }
@@ -93,7 +93,7 @@ class ImportCommandTest {
     @Test
     void execute_fileNotFound_throwsException() {
         Ui ui = createUiWithInput("");
-        ImportCommand cmd = new ImportCommand("--file nonexistent.csv");
+        ImportCommand cmd = new ImportCommand("nonexistent.csv");
         assertThrows(RLADException.class, () -> cmd.execute(tm, ui));
     }
 
@@ -106,7 +106,7 @@ class ImportCommandTest {
         Files.writeString(file, content);
 
         Ui ui = createUiWithInput("");
-        ImportCommand cmd = new ImportCommand("--file " + file);
+        ImportCommand cmd = new ImportCommand(file.toString());
         cmd.execute(tm, ui);
         assertEquals(1, tm.getTransactionCount());
     }
@@ -119,30 +119,31 @@ class ImportCommandTest {
         Files.writeString(file, content);
 
         Ui ui = createUiWithInput("");
-        ImportCommand cmd = new ImportCommand("--file " + file);
+        ImportCommand cmd = new ImportCommand(file.toString());
         assertThrows(RLADException.class, () -> cmd.execute(tm, ui));
     }
 
     @Test
     void hasValidArgs_alwaysTrue() {
-        assertEquals(true, new ImportCommand("--file test.csv").hasValidArgs());
-        assertEquals(true, new ImportCommand("--merge").hasValidArgs());
+        assertEquals(true, new ImportCommand("test.csv").hasValidArgs());
+        assertEquals(true, new ImportCommand("test.csv merge").hasValidArgs());
         assertEquals(true, new ImportCommand("").hasValidArgs());
     }
 
     @Test
-    void execute_missingFileFlag_throwsException() {
+    void execute_missingFilename_throwsException() {
         Ui ui = createUiWithInput("");
-        ImportCommand cmd = new ImportCommand("--merge");
+        ImportCommand cmd = new ImportCommand("");
         RLADException ex = assertThrows(RLADException.class, () -> cmd.execute(tm, ui));
-        assertTrue(ex.getMessage().contains("--file is required"));
+        assertTrue(ex.getMessage().contains("Filename is required"));
     }
 
     @Test
-    void execute_emptyFileFlag_throwsException() {
+    void execute_unknownArgument_throwsException() throws Exception {
+        Path file = createValidCsv("unknown.csv");
         Ui ui = createUiWithInput("");
-        ImportCommand cmd = new ImportCommand("--file");
+        ImportCommand cmd = new ImportCommand(file + " bogus");
         RLADException ex = assertThrows(RLADException.class, () -> cmd.execute(tm, ui));
-        assertTrue(ex.getMessage().contains("--file is required"));
+        assertTrue(ex.getMessage().contains("Unknown argument"));
     }
 }


### PR DESCRIPTION
- ExportCommand: 'export [filename]' instead of '--file FILE --path DIR'
- ImportCommand: 'import <filename> [merge]' instead of '--file FILE [--merge]'
- Update ExportCommandTest and ImportCommandTest to match UG syntax
- Fixes bug where export silently ignored filename and import blocked users