### PR TITLE
Fix/modify unknown fields

### DIFF
--- a/src/main/java/seedu/RLAD/command/ModifyCommand.java
+++ b/src/main/java/seedu/RLAD/command/ModifyCommand.java
@@ -11,6 +11,7 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.ResolverStyle;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 public class ModifyCommand extends Command {
 
@@ -57,6 +58,15 @@ public class ModifyCommand extends Command {
         // After parsing updates, check if there are any
         if (updates.isEmpty()) {
             throw new RLADException("No fields to update. Usage: modify <hashID> field=value [field=value ...]");
+        }
+
+        // Reject unknown field names
+        Set<String> validFields = Set.of("type", "amount", "date", "category", "description");
+        for (String key : updates.keySet()) {
+            if (!validFields.contains(key)) {
+                throw new RLADException("Unknown field: '" + key + "'. "
+                        + "Valid fields: type, amount, date, category, description");
+            }
         }
 
         // Apply updates

--- a/src/test/java/seedu/RLAD/command/ModifyCommandTest.java
+++ b/src/test/java/seedu/RLAD/command/ModifyCommandTest.java
@@ -119,4 +119,12 @@ class ModifyCommandTest {
         Transaction updated = manager.findTransaction(existingId);
         assertEquals(existingId, updated.getHashId());
     }
+
+    @Test
+    void execute_unknownField_throwsException() {
+        RLADException ex = assertThrows(RLADException.class, () ->
+                new ModifyCommand(existingId + " foo=1").execute(manager, ui));
+        assertTrue(ex.getMessage().contains("Unknown field"));
+        assertTrue(ex.getMessage().contains("foo"));
+    }
 }


### PR DESCRIPTION
Summary
Validate field names in modify command against known fields (type, amount, date, category, description)
Throw a clear error for unknown fields instead of silently ignoring them
Test plan
 Run modify <id> foo=1 and verify error: "Unknown field: 'foo'"
 Run modify <id> amount=25.00 and verify it still works normally