### PR TITLE
Fix/zero amount rounding

### DIFF
--- a/src/main/java/seedu/RLAD/command/AddCommand.java
+++ b/src/main/java/seedu/RLAD/command/AddCommand.java
@@ -138,7 +138,11 @@ public class AddCommand extends Command {
         }
 
         // Round to 2 decimal places for consistency
-        return Math.round(amount * 100.0) / 100.0;
+        double rounded = Math.round(amount * 100.0) / 100.0;
+        if (rounded <= 0) {
+            throw new RLADException("Amount rounds to $0.00. Minimum is $0.01.");
+        }
+        return rounded;
     }
 
     /**

--- a/src/main/java/seedu/RLAD/command/ModifyCommand.java
+++ b/src/main/java/seedu/RLAD/command/ModifyCommand.java
@@ -95,7 +95,11 @@ public class ModifyCommand extends Command {
             if (value > MAX_AMOUNT) {
                 throw new RLADException(String.format("Amount cannot exceed $%,.2f", MAX_AMOUNT));
             }
-            return value;
+            double rounded = Math.round(value * 100.0) / 100.0;
+            if (rounded <= 0) {
+                throw new RLADException("Amount rounds to $0.00. Minimum is $0.01.");
+            }
+            return rounded;
         } catch (NumberFormatException e) {
             throw new RLADException("Invalid amount");
         }

--- a/src/test/java/seedu/RLAD/command/AddCommandTest.java
+++ b/src/test/java/seedu/RLAD/command/AddCommandTest.java
@@ -122,6 +122,20 @@ public class AddCommandTest {
             System.out.println("✗ FAIL: " + e.getMessage() + "\n");
         }
 
+        // Test 12: Amount that rounds to $0.00 should be rejected
+        System.out.println("Test 12: Amount 0.001 rounds to $0.00");
+        try {
+            AddCommand cmd12 = new AddCommand("credit 0.001 2026-03-01 food");
+            cmd12.execute(tm, ui);
+            System.out.println("✗ FAIL: Should have thrown exception\n");
+        } catch (RLADException e) {
+            if (e.getMessage().contains("$0.00") || e.getMessage().contains("0.01")) {
+                System.out.println("✓ PASS: " + e.getMessage() + "\n");
+            } else {
+                System.out.println("✗ FAIL: Wrong message: " + e.getMessage() + "\n");
+            }
+        }
+
         // Show final transactions
         System.out.println("\n=== FINAL TRANSACTIONS ===");
         if (tm.getTransactions().isEmpty()) {

--- a/src/test/java/seedu/RLAD/command/ModifyCommandTest.java
+++ b/src/test/java/seedu/RLAD/command/ModifyCommandTest.java
@@ -119,4 +119,11 @@ class ModifyCommandTest {
         Transaction updated = manager.findTransaction(existingId);
         assertEquals(existingId, updated.getHashId());
     }
+
+    @Test
+    void execute_amountRoundsToZero_throwsException() {
+        RLADException ex = assertThrows(RLADException.class, () ->
+                new ModifyCommand(existingId + " amount=0.001").execute(manager, ui));
+        assertTrue(ex.getMessage().contains("$0.00") || ex.getMessage().contains("0.01"));
+    }
 }


### PR DESCRIPTION
Summary
Validate amount after rounding to 2 decimal places, not just before
add credit 0.001 ... now throws "Amount rounds to $0.00. Minimum is $0.01" instead of silently creating a $0.00 transaction
Applied to both AddCommand and ModifyCommand
Test plan
 Run add credit 0.001 2026-03-01 food and verify rejection
 Run add credit 0.01 2026-03-01 food and verify it works ($0.01)
 Run modify <id> amount=0.004 and verify rejection