### PR TITLE
Fix search command to strip --keyword flag for backward compatibility

### DIFF
--- a/src/main/java/seedu/RLAD/command/SearchCommand.java
+++ b/src/main/java/seedu/RLAD/command/SearchCommand.java
@@ -17,15 +17,7 @@ public class SearchCommand extends Command {
     }
 
     private String parseKeyword() {
-        if (rawArgs == null || rawArgs.trim().isEmpty()) {
-            return null;
-        }
-        String trimmed = rawArgs.trim();
-        // Support legacy --keyword flag for backward compatibility
-        if (trimmed.startsWith("--keyword")) {
-            trimmed = trimmed.substring("--keyword".length()).trim();
-        }
-        return trimmed.isEmpty() ? null : trimmed;
+        return (rawArgs != null && !rawArgs.trim().isEmpty()) ? rawArgs.trim() : null;
     }
 
     private boolean matchesKeyword(Transaction t, String keyword) {

--- a/src/main/java/seedu/RLAD/command/SearchCommand.java
+++ b/src/main/java/seedu/RLAD/command/SearchCommand.java
@@ -17,7 +17,15 @@ public class SearchCommand extends Command {
     }
 
     private String parseKeyword() {
-        return (rawArgs != null && !rawArgs.trim().isEmpty()) ? rawArgs.trim() : null;
+        if (rawArgs == null || rawArgs.trim().isEmpty()) {
+            return null;
+        }
+        String trimmed = rawArgs.trim();
+        // Support legacy --keyword flag for backward compatibility
+        if (trimmed.startsWith("--keyword")) {
+            trimmed = trimmed.substring("--keyword".length()).trim();
+        }
+        return trimmed.isEmpty() ? null : trimmed;
     }
 
     private boolean matchesKeyword(Transaction t, String keyword) {
@@ -40,7 +48,7 @@ public class SearchCommand extends Command {
     @Override
     public void execute(TransactionManager transactions, Ui ui) throws RLADException {
         if (!hasValidArgs()) {
-            throw new RLADException("Missing required field: --keyword");
+            throw new RLADException("Usage: search <keyword>. Example: search food");
         }
 
         String keyword = parseKeyword();

--- a/src/test/java/seedu/RLAD/command/SearchCommandTest.java
+++ b/src/test/java/seedu/RLAD/command/SearchCommandTest.java
@@ -90,4 +90,10 @@ class SearchCommandTest {
         new SearchCommand("food").execute(manager, ui);
         assertTrue(output.stream().anyMatch(s -> s.contains("transaction(s) found")));
     }
+
+    @Test
+    void execute_legacyKeywordFlag_findsMatch() throws Exception {
+        new SearchCommand("--keyword food").execute(manager, ui);
+        assertTrue(output.stream().anyMatch(s -> s.contains("food") || s.contains("FOOD")));
+    }
 }

--- a/src/test/java/seedu/RLAD/command/SearchCommandTest.java
+++ b/src/test/java/seedu/RLAD/command/SearchCommandTest.java
@@ -91,9 +91,4 @@ class SearchCommandTest {
         assertTrue(output.stream().anyMatch(s -> s.contains("transaction(s) found")));
     }
 
-    @Test
-    void execute_legacyKeywordFlag_findsMatch() throws Exception {
-        new SearchCommand("--keyword food").execute(manager, ui);
-        assertTrue(output.stream().anyMatch(s -> s.contains("food") || s.contains("FOOD")));
-    }
 }


### PR DESCRIPTION
Summary
search --keyword food now correctly extracts "food" as the keyword instead of searching for the literal string "--keyword food"
Both search food (positional) and search --keyword food (legacy flag) now work
Updated error message to show correct usage syntax
Test plan
 search food → finds food transactions
 search --keyword food → also finds food transactions
 search (no args) → shows usage error