### PR TITLE
Fix min > max filter producing silent empty results instead of error

### DIFF
--- a/src/main/java/seedu/RLAD/command/FilterCommand.java
+++ b/src/main/java/seedu/RLAD/command/FilterCommand.java
@@ -284,6 +284,9 @@ public class FilterCommand extends Command {
         String[] parts = filterStr.split("\\s+");
         List<Transaction> result = new ArrayList<>(transactions);
 
+        double minVal = -1;
+        double maxVal = -1;
+
         for (String part : parts) {
             String token = part.toLowerCase();
             if (!token.contains(":")) {
@@ -326,12 +329,14 @@ public class FilterCommand extends Command {
                 break;
             case "min":
                 double minAmt = parseColonAmount(value);
+                minVal = minAmt;
                 result = result.stream()
                         .filter(t -> t.getAmount() >= minAmt)
                         .collect(Collectors.toList());
                 break;
             case "max":
                 double maxAmt = parseColonAmount(value);
+                maxVal = maxAmt;
                 result = result.stream()
                         .filter(t -> t.getAmount() <= maxAmt)
                         .collect(Collectors.toList());
@@ -341,6 +346,13 @@ public class FilterCommand extends Command {
                         + "'. Available: type, cat, from, to, min, max");
             }
         }
+
+        if (minVal >= 0 && maxVal >= 0 && minVal > maxVal) {
+            throw new RLADException(String.format(
+                    "min:%.2f is greater than max:%.2f. "
+                            + "This range will never match any transactions.", minVal, maxVal));
+        }
+
         return result;
     }
 

--- a/src/main/java/seedu/RLAD/command/FilterCommand.java
+++ b/src/main/java/seedu/RLAD/command/FilterCommand.java
@@ -284,8 +284,28 @@ public class FilterCommand extends Command {
         String[] parts = filterStr.split("\\s+");
         List<Transaction> result = new ArrayList<>(transactions);
 
-        double minVal = -1;
-        double maxVal = -1;
+        // Pre-scan for min/max to validate range before filtering
+        boolean hasMin = false;
+        boolean hasMax = false;
+        double minVal = 0;
+        double maxVal = 0;
+
+        for (String part : parts) {
+            String token = part.toLowerCase();
+            if (token.startsWith("min:")) {
+                minVal = parseColonAmount(token.substring(4));
+                hasMin = true;
+            } else if (token.startsWith("max:")) {
+                maxVal = parseColonAmount(token.substring(4));
+                hasMax = true;
+            }
+        }
+
+        if (hasMin && hasMax && minVal > maxVal) {
+            throw new RLADException(String.format(
+                    "min:%.2f is greater than max:%.2f. "
+                            + "This range will never match any transactions.", minVal, maxVal));
+        }
 
         for (String part : parts) {
             String token = part.toLowerCase();
@@ -329,14 +349,12 @@ public class FilterCommand extends Command {
                 break;
             case "min":
                 double minAmt = parseColonAmount(value);
-                minVal = minAmt;
                 result = result.stream()
                         .filter(t -> t.getAmount() >= minAmt)
                         .collect(Collectors.toList());
                 break;
             case "max":
                 double maxAmt = parseColonAmount(value);
-                maxVal = maxAmt;
                 result = result.stream()
                         .filter(t -> t.getAmount() <= maxAmt)
                         .collect(Collectors.toList());
@@ -345,12 +363,6 @@ public class FilterCommand extends Command {
                 throw new RLADException("Unknown filter: '" + key
                         + "'. Available: type, cat, from, to, min, max");
             }
-        }
-
-        if (minVal >= 0 && maxVal >= 0 && minVal > maxVal) {
-            throw new RLADException(String.format(
-                    "min:%.2f is greater than max:%.2f. "
-                            + "This range will never match any transactions.", minVal, maxVal));
         }
 
         return result;

--- a/src/test/java/seedu/RLAD/FilterCommandTest.java
+++ b/src/test/java/seedu/RLAD/FilterCommandTest.java
@@ -394,4 +394,22 @@ class FilterCommandTest {
         ArrayList<Transaction> results = applyCategoryFilter("--category nonexistent");
         assertEquals(0, results.size());
     }
+
+    @Test
+    public void applyColonFilters_minGreaterThanMax_throwsException() {
+        ArrayList<Transaction> transactions = createSampleTransactions();
+        assertThrows(RLADException.class,
+                () -> FilterCommand.applyColonFilters(transactions, "min:100 max:50"));
+    }
+
+    @Test
+    public void applyColonFilters_validMinMax_filtersCorrectly() throws RLADException {
+        ArrayList<Transaction> transactions = createSampleTransactions();
+        java.util.List<Transaction> results =
+                FilterCommand.applyColonFilters(transactions, "min:10 max:200");
+        for (Transaction t : results) {
+            assertTrue(t.getAmount() >= 10 && t.getAmount() <= 200);
+        }
+        assertEquals(2, results.size());
+    }
 }


### PR DESCRIPTION
When users specify min:100 max:50, the filter now throws an informative error instead of silently returning no results. Added tests for min/max validation and valid range filtering.