### PR TITLE
Fix import/export ignoring --file flag causing file not found errors

### DIFF
--- a/src/main/java/seedu/RLAD/command/ExportCommand.java
+++ b/src/main/java/seedu/RLAD/command/ExportCommand.java
@@ -33,6 +33,14 @@ public class ExportCommand extends Command {
     @Override
     public void execute(TransactionManager transactions, Ui ui) throws RLADException {
         String filename = rawArgs == null ? "" : rawArgs.trim();
+
+        // Support legacy --file flag for backward compatibility
+        if (filename.startsWith("--file ")) {
+            filename = filename.substring("--file ".length()).trim();
+        } else if (filename.equals("--file")) {
+            filename = "";
+        }
+
         if (filename.isEmpty()) {
             filename = "transactions_"
                     + LocalDate.now().format(DateTimeFormatter.ISO_LOCAL_DATE) + ".csv";

--- a/src/main/java/seedu/RLAD/command/ImportCommand.java
+++ b/src/main/java/seedu/RLAD/command/ImportCommand.java
@@ -28,6 +28,13 @@ public class ImportCommand extends Command {
     public void execute(TransactionManager transactions, Ui ui) throws RLADException {
         String args = rawArgs == null ? "" : rawArgs.trim();
 
+        // Support legacy --file flag for backward compatibility
+        if (args.startsWith("--file ")) {
+            args = args.substring("--file ".length()).trim();
+        } else if (args.equals("--file")) {
+            args = "";
+        }
+
         boolean mergeMode = false;
         if (args.toLowerCase().endsWith(" merge")) {
             mergeMode = true;


### PR DESCRIPTION
Strip legacy --file flag prefix in ImportCommand and ExportCommand so that both positional and flag-based syntax work correctly.