### PR TITLE
Validate NaN/Infinity/negative amounts when loading from storage

### DIFF
--- a/src/main/java/seedu/RLAD/budget/BudgetManager.java
+++ b/src/main/java/seedu/RLAD/budget/BudgetManager.java
@@ -502,6 +502,10 @@ public class BudgetManager {
                     YearMonth month = YearMonth.parse(parts[0].trim());
                     int code = Integer.parseInt(parts[1].trim());
                     double amount = Double.parseDouble(parts[2].trim());
+                    if (amount <= 0 || Double.isNaN(amount) || Double.isInfinite(amount)) {
+                        logger.warning("Skipping invalid budget amount: " + line);
+                        continue;
+                    }
                     BudgetCategory category = BudgetCategory.fromCode(code);
                     getOrCreateBudget(month).setBudget(category, amount);
                 } catch (Exception e) {

--- a/src/main/java/seedu/RLAD/storage/AutoSaveManager.java
+++ b/src/main/java/seedu/RLAD/storage/AutoSaveManager.java
@@ -117,6 +117,10 @@ public class AutoSaveManager {
             String type = parts[1];
             String category = parts[2].isEmpty() ? null : parts[2];
             double amount = Double.parseDouble(parts[3]);
+            if (amount < 0 || Double.isNaN(amount) || Double.isInfinite(amount)) {
+                logger.warning("Skipping autosave line " + lineNum + ": invalid amount " + parts[3]);
+                return null;
+            }
             LocalDate date = LocalDate.parse(parts[4]);
             String description = parts.length > 5 && !parts[5].isEmpty() ? parts[5] : null;
 
@@ -151,6 +155,11 @@ public class AutoSaveManager {
                     String type = parts[1];
                     String category = parts[2].isEmpty() ? null : parts[2];
                     double amount = Double.parseDouble(parts[3]);
+                    if (amount < 0 || Double.isNaN(amount) || Double.isInfinite(amount)) {
+                        logger.warning("Skipping legacy line " + lineNum
+                                + ": invalid amount " + parts[3]);
+                        continue;
+                    }
                     LocalDate date = LocalDate.parse(parts[4]);
                     String description = parts.length > 5 && !parts[5].isEmpty() ? parts[5] : null;
 

--- a/src/main/java/seedu/RLAD/storage/CsvStorageManager.java
+++ b/src/main/java/seedu/RLAD/storage/CsvStorageManager.java
@@ -158,8 +158,8 @@ public class CsvStorageManager {
         } catch (NumberFormatException e) {
             throw new RLADException("invalid amount '" + columns[3].trim() + "'");
         }
-        if (amount < 0) {
-            throw new RLADException("amount must not be negative: " + columns[3].trim());
+        if (amount < 0 || Double.isNaN(amount) || Double.isInfinite(amount)) {
+            throw new RLADException("amount must be a finite non-negative number: " + columns[3].trim());
         }
 
         LocalDate date;


### PR DESCRIPTION
Add amount validation in AutoSaveManager (CSV and legacy), CsvStorageManager import, and BudgetManager CSV loading to reject corrupted entries that would crash summarize or display as $NaN.