### PR TITLE
Skip empty filter keys to avoid ugly error on malformed input

### DIFF
--- a/src/main/java/seedu/RLAD/command/FilterCommand.java
+++ b/src/main/java/seedu/RLAD/command/FilterCommand.java
@@ -293,6 +293,10 @@ public class FilterCommand extends Command {
             String key = kv[0];
             String value = kv[1];
 
+            if (key.isEmpty()) {
+                continue;
+            }
+
             switch (key) {
             case "type":
                 result = result.stream()


### PR DESCRIPTION
Filters like ':::' produced empty keys after splitting on ':' which triggered 'Unknown filter' errors. Now silently skipped.