### PR TITLE
Improve budget display when spending exceeds total budget

### DIFF
--- a/src/main/java/seedu/RLAD/budget/BudgetCommand.java
+++ b/src/main/java/seedu/RLAD/budget/BudgetCommand.java
@@ -218,14 +218,22 @@ public class BudgetCommand extends Command {
         int totalPercentage = totalBudget > 0 ? (int) ((totalSpentAll / totalBudget) * 100) : 0;
         String totalBar = createProgressBar(totalPercentage, PROGRESS_BAR_LENGTH);
 
-        output.add(String.format("%-25s | $%,12.2f | $%,12.2f | $%,12.2f | %s %3d%%",
+        String remainingDisplay = totalRemaining < 0
+                ? String.format("-$%,.2f", Math.abs(totalRemaining))
+                : String.format("$%,.2f", totalRemaining);
+
+        output.add(String.format("%-25s | $%,12.2f | $%,12.2f | %14s | %s %3d%%",
                 "TOTAL",
                 totalBudget,
                 totalSpentAll,
-                totalRemaining,
+                remainingDisplay,
                 totalBar,
                 totalPercentage
         ));
+        if (totalRemaining < 0) {
+            output.add("⚠ Total spending exceeds budget by "
+                    + String.format("$%,.2f", Math.abs(totalRemaining)));
+        }
 
         // Display
         output.forEach(ui::showResult);


### PR DESCRIPTION
Show negative remaining as -$X.XX format and add a warning message when total spending exceeds the budgeted amount.