### PR TITLE
Reject amounts with >2 decimal places and scientific notation

### DIFF
--- a/src/main/java/seedu/RLAD/command/AddCommand.java
+++ b/src/main/java/seedu/RLAD/command/AddCommand.java
@@ -116,6 +116,21 @@ public class AddCommand extends Command {
      * @throws RLADException If amount is not a positive number or exceeds limits
      */
     private double parseAndValidateAmount(String amountStr) throws RLADException {
+        // Reject scientific notation (e.g., 1e5, 2.5E-3)
+        if (amountStr.matches(".*[eE].*")) {
+            throw new RLADException("Invalid amount: '" + amountStr
+                    + "'. Scientific notation is not allowed. Use standard format (e.g., 15.50)");
+        }
+
+        // Reject more than 2 decimal places
+        if (amountStr.contains(".")) {
+            String[] decimalParts = amountStr.split("\\.");
+            if (decimalParts.length == 2 && decimalParts[1].length() > 2) {
+                throw new RLADException("Invalid amount: '" + amountStr
+                        + "'. Maximum 2 decimal places allowed (e.g., 15.50)");
+            }
+        }
+
         double amount;
         try {
             amount = Double.parseDouble(amountStr);

--- a/src/main/java/seedu/RLAD/command/ModifyCommand.java
+++ b/src/main/java/seedu/RLAD/command/ModifyCommand.java
@@ -99,6 +99,21 @@ public class ModifyCommand extends Command {
     }
 
     private double parseAmount(String amountStr) throws RLADException {
+        // Reject scientific notation (e.g., 1e5, 2.5E-3)
+        if (amountStr.matches(".*[eE].*")) {
+            throw new RLADException("Invalid amount: '" + amountStr
+                    + "'. Scientific notation is not allowed.");
+        }
+
+        // Reject more than 2 decimal places
+        if (amountStr.contains(".")) {
+            String[] decimalParts = amountStr.split("\\.");
+            if (decimalParts.length == 2 && decimalParts[1].length() > 2) {
+                throw new RLADException("Invalid amount: '" + amountStr
+                        + "'. Maximum 2 decimal places allowed.");
+            }
+        }
+
         try {
             double value = Double.parseDouble(amountStr);
             if (Double.isNaN(value) || Double.isInfinite(value)) {

--- a/src/test/java/seedu/RLAD/command/ModifyCommandTest.java
+++ b/src/test/java/seedu/RLAD/command/ModifyCommandTest.java
@@ -124,6 +124,7 @@ class ModifyCommandTest {
     void execute_amountRoundsToZero_throwsException() {
         RLADException ex = assertThrows(RLADException.class, () ->
                 new ModifyCommand(existingId + " amount=0.001").execute(manager, ui));
-        assertTrue(ex.getMessage().contains("$0.00") || ex.getMessage().contains("0.01"));
+        assertTrue(ex.getMessage().contains("decimal") || ex.getMessage().contains("$0.00")
+                || ex.getMessage().contains("0.01"));
     }
 }


### PR DESCRIPTION
Validate amount format before parsing to reject inputs like 15.999 (too many decimals) and 1e5 (scientific notation) as documented in the User Guide.