### PR TITLE
Validate type filter value in list command

### DIFF
--- a/src/main/java/seedu/RLAD/command/FilterCommand.java
+++ b/src/main/java/seedu/RLAD/command/FilterCommand.java
@@ -295,7 +295,7 @@ public class FilterCommand extends Command {
 
             switch (key) {
             case "type":
-                if (!value.equals("credit") && !value.equals("debit")) {
+                if (!value.equalsIgnoreCase("credit") && !value.equalsIgnoreCase("debit")) {
                     throw new RLADException("Invalid type: '" + value
                             + "'. Use 'credit' or 'debit'.");
                 }

--- a/src/main/java/seedu/RLAD/command/FilterCommand.java
+++ b/src/main/java/seedu/RLAD/command/FilterCommand.java
@@ -295,6 +295,10 @@ public class FilterCommand extends Command {
 
             switch (key) {
             case "type":
+                if (!value.equals("credit") && !value.equals("debit")) {
+                    throw new RLADException("Invalid type: '" + value
+                            + "'. Use 'credit' or 'debit'.");
+                }
                 result = result.stream()
                         .filter(t -> t.getType().equalsIgnoreCase(value))
                         .collect(Collectors.toList());

--- a/src/test/java/seedu/RLAD/FilterCommandTest.java
+++ b/src/test/java/seedu/RLAD/FilterCommandTest.java
@@ -411,6 +411,8 @@ class FilterCommandTest {
         for (Transaction t : results) {
             assertEquals("credit", t.getType());
         }
+    }
+        
     public void applyColonFilters_minGreaterThanMax_throwsException() {
         ArrayList<Transaction> transactions = createSampleTransactions();
         assertThrows(RLADException.class,

--- a/src/test/java/seedu/RLAD/FilterCommandTest.java
+++ b/src/test/java/seedu/RLAD/FilterCommandTest.java
@@ -394,4 +394,22 @@ class FilterCommandTest {
         ArrayList<Transaction> results = applyCategoryFilter("--category nonexistent");
         assertEquals(0, results.size());
     }
+
+    @Test
+    public void applyColonFilters_invalidType_throwsException() {
+        ArrayList<Transaction> transactions = createSampleTransactions();
+        assertThrows(RLADException.class,
+                () -> FilterCommand.applyColonFilters(transactions, "type:invalid"));
+    }
+
+    @Test
+    public void applyColonFilters_uppercaseType_filtersCorrectly() throws RLADException {
+        ArrayList<Transaction> transactions = createSampleTransactions();
+        java.util.List<Transaction> results =
+                FilterCommand.applyColonFilters(transactions, "type:CREDIT");
+        assertEquals(2, results.size());
+        for (Transaction t : results) {
+            assertEquals("credit", t.getType());
+        }
+    }
 }


### PR DESCRIPTION
Reject invalid type filter values like 'list type:invalid' with a clear error message instead of silently returning no results.