### PR TITLE
Reject zero amount during CSV import to match add command validation

### DIFF
--- a/src/main/java/seedu/RLAD/storage/CsvStorageManager.java
+++ b/src/main/java/seedu/RLAD/storage/CsvStorageManager.java
@@ -158,8 +158,8 @@ public class CsvStorageManager {
         } catch (NumberFormatException e) {
             throw new RLADException("invalid amount '" + columns[3].trim() + "'");
         }
-        if (amount < 0) {
-            throw new RLADException("amount must not be negative: " + columns[3].trim());
+        if (amount <= 0) {
+            throw new RLADException("amount must be greater than 0: " + columns[3].trim());
         }
 
         LocalDate date;


### PR DESCRIPTION
Changed amount check from < 0 to <= 0 so that $0.00 transactions are rejected during import, consistent with add command behavior.