### PR TITLE
Require -- prefix for clear force flag as documented in User Guide

### DIFF
--- a/src/main/java/seedu/RLAD/command/ClearCommand.java
+++ b/src/main/java/seedu/RLAD/command/ClearCommand.java
@@ -4,16 +4,10 @@ import seedu.RLAD.TransactionManager;
 import seedu.RLAD.Ui;
 import seedu.RLAD.exception.RLADException;
 
-import java.util.Map;
-import java.util.Arrays;
-import java.util.HashSet;
-
 /**
  * Clears all transactions from storage after user confirmation.
  */
 public class ClearCommand extends Command {
-
-    private static final HashSet<String> VALID_FLAGS = new HashSet<>(Arrays.asList("force"));
 
     /**
      * Creates a new ClearCommand.
@@ -29,9 +23,8 @@ public class ClearCommand extends Command {
         if (!hasValidArgs()) {
             throw new RLADException(getInvalidArgsMessage());
         }
-        Map<String, String> flags = FilterCommand.parseFlags(rawArgs);
-        boolean forceMode = flags.keySet().stream()
-                .anyMatch(f -> f.equalsIgnoreCase("force"));
+        String trimmedArgs = rawArgs == null ? "" : rawArgs.trim();
+        boolean forceMode = trimmedArgs.equalsIgnoreCase("--force");
 
         int count = transactions.getTransactionCount();
         if (count == 0) {
@@ -58,13 +51,8 @@ public class ClearCommand extends Command {
         if (rawArgs == null || rawArgs.trim().isEmpty()) {
             return true;
         }
-        Map<String, String> flags = FilterCommand.parseFlags(rawArgs);
-        for (String flag : flags.keySet()) {
-            if (!VALID_FLAGS.contains(flag.toLowerCase())) {
-                return false;
-            }
-        }
-        return true;
+        String trimmed = rawArgs.trim();
+        return trimmed.equalsIgnoreCase("--force");
     }
 
     /**


### PR DESCRIPTION
Only accept 'clear --force' to skip confirmation, rejecting bare 'clear force' which was undocumented but silently worked.