### PR TITLE
Reject extra arguments in sort command

### DIFF
--- a/src/main/java/seedu/RLAD/command/SortCommand.java
+++ b/src/main/java/seedu/RLAD/command/SortCommand.java
@@ -34,6 +34,10 @@ public class SortCommand extends Command {
             return;
         }
 
+        if (parts.length > 2) {
+            throw new RLADException("Too many arguments. Usage: sort [amount|date] [asc|desc]");
+        }
+
         String direction = parts.length > 1 ? parts[1].toLowerCase() : "asc";
 
         if (!TransactionSorter.isValidSortField(field)) {


### PR DESCRIPTION
Validate that sort accepts at most 2 arguments (field and direction) instead of silently ignoring additional input.