### PR TITLE
Reject budget set when budget already exists for that category

### DIFF
--- a/src/main/java/seedu/RLAD/budget/BudgetCommand.java
+++ b/src/main/java/seedu/RLAD/budget/BudgetCommand.java
@@ -91,6 +91,18 @@ public class BudgetCommand extends Command {
         int categoryCode = parseCategoryCode(parts[2]);
         double amount = parseAmount(parts[3]);
 
+        // Check if budget already exists for this category
+        BudgetCategory category = BudgetCategory.fromCode(categoryCode);
+        Optional<MonthlyBudget> existing = budgetManager.getBudget(month);
+        if (existing.isPresent() && existing.get().getBudgetForCategory(category) > 0) {
+            throw new RLADException(String.format(
+                    "Budget already exists for %s in %s ($%,.2f). "
+                            + "Use 'budget edit %s %d <amount>' to update it.",
+                    category.getDisplayName(), month,
+                    existing.get().getBudgetForCategory(category),
+                    month, categoryCode));
+        }
+
         budgetManager.setBudget(month, categoryCode, amount);
         ui.showResult(String.format("✅ Budget set: %s - Category %d: $%,.2f", month, categoryCode, amount));
     }


### PR DESCRIPTION
Check for existing budget before setting and direct user to use budget edit instead, matching the documented behavior in the FAQ.