### PR TITLE
Fix modify command dropping quoted description values with spaces

### DIFF
--- a/src/main/java/seedu/RLAD/command/ModifyCommand.java
+++ b/src/main/java/seedu/RLAD/command/ModifyCommand.java
@@ -118,7 +118,6 @@ public class ModifyCommand extends Command {
             char c = input.charAt(i);
             if (c == '"') {
                 inQuotes = !inQuotes;
-                current.append(c);
             } else if (c == ' ' && !inQuotes) {
                 if (current.length() > 0) {
                     tokens.add(removeSurroundingQuotes(current.toString()));


### PR DESCRIPTION
## Summary
- Fixes #80: `modify` crashes when description contains spaces
- Root cause: `parseWithQuotes` was appending the `"` character into the token buffer, causing values like `"Fancy chicken rice"` to retain their quotes and fail `field=value` parsing
- Fix: stop appending `"` — just toggle the `inQuotes` flag and discard the character, so `description="Fancy chicken rice"` correctly produces value `Fancy chicken rice`

## Test plan
- [ ] `add debit 10 2026-01-01 food test` then `modify <id> description="Fancy chicken rice"` — should update description successfully
- [ ] All 12 existing `ModifyCommandTest` tests pass
- [ ] Full test suite passes