### PR TITLE
Fix CSV formula injection and add autosave integrity check

### DIFF
--- a/docs/team/DeveloperGuide.md
+++ b/docs/team/DeveloperGuide.md
@@ -1049,6 +1049,7 @@ sequenceDiagram
 **CSV escaping rules:**
 - If a field contains a comma, double-quote, or newline, wrap it in double-quotes.
 - Any existing double-quote characters within the field are doubled (`"` becomes `""`).
+- If a field's first non-whitespace character is `=`, `+`, `-`, or `@`, a tab character is prepended to neutralise CSV formula injection. Spreadsheet applications such as Excel and Google Sheets treat any cell that starts with a tab as plain text rather than a formula. The tab is stripped by `String.stripLeading()` + `.trim()` during re-import so the original value is restored exactly. Leading whitespace in the raw user input is normalised at write time so a manually typed tab cannot bypass this check.
 
 #### 4.8.2 Import (`ImportCommand` + `CsvStorageManager.importFromCsv`)
 
@@ -1227,6 +1228,16 @@ Fields containing commas or quotes are wrapped in double quotes per RFC 4180. If
 **Why overwrite the entire file?** The transaction list is small enough that a full rewrite on every change is fast and avoids the complexity of incremental updates or journaling. This also guarantees the file is always in a consistent state.
 
 **Graceful degradation:** If the autosave file is missing or corrupted, RLAD starts with an empty transaction list. Malformed lines are skipped with a log warning rather than crashing.
+
+#### Integrity Verification
+
+After every save, `AutoSaveManager` computes the SHA-256 digest of `data/rlad.csv` and writes it as a 64-character hex string to `data/rlad.csv.sha256`. On the next startup, before any rows are parsed, the stored digest is compared against a freshly computed digest of the file:
+
+- **Match** — file is intact, load proceeds silently.
+- **Mismatch** — a warning is printed to stdout before the welcome screen. Data still loads; the user is advised to review their transactions.
+- **Hash file absent** — treated as a match (first run or pre-feature install). No warning is shown.
+
+This provides a lightweight tamper-detection signal without blocking the user. The hash file is not a cryptographic authentication mechanism — a user who edits the CSV can also update the hash file — but it catches accidental corruption and makes unintended external edits visible.
 
 ### 4.10 Help Command
 

--- a/docs/team/UserGuide.md
+++ b/docs/team/UserGuide.md
@@ -401,6 +401,8 @@ a7b2c3,credit,salary,3000.00,2026-03-01,March salary
 d4e5f6,debit,food,15.50,2026-03-05,"Chicken rice at Clementi"
 ```
 
+> **Note:** Fields whose content starts with `=`, `+`, `-`, or `@` are automatically prefixed with a tab character in the exported file. This prevents spreadsheet applications such as Excel and Google Sheets from interpreting them as formulas. When the file is re-imported into RLAD the tab is stripped and the original value is restored exactly.
+
 > **Tip:** Use `export` before any destructive operation (`clear`, `import` without `merge`) to preserve a backup of your data.
 
 ---
@@ -652,11 +654,14 @@ RLAD automatically saves all transactions to a local file after every change. No
 | File              | Purpose                                        |
 |-------------------|------------------------------------------------|
 | `data/rlad.csv`        | Primary data store — transactions               |
+| `data/rlad.csv.sha256` | Integrity hash — verified on every startup      |
 | `data/rlad_budget.csv` | Budget definitions and allocations              |
 
 Your data is restored automatically the next time you launch RLAD from the same directory. Use `export` to create a portable CSV backup that can be opened in Excel or Google Sheets.
 
 > **Note:** If `data/rlad.csv` is deleted or corrupted, RLAD will start with an empty state. Keep regular CSV exports as offsite backups.
+
+> **Note:** On every startup RLAD verifies `data/rlad.csv` against its stored SHA-256 hash. If the file was modified outside of RLAD you will see a warning — your data still loads, but you should review your transactions for unexpected changes.
 
 ---
 
@@ -702,7 +707,13 @@ It is the portion of your recorded credits for that month that has not been allo
 
 **Q: Can I import a CSV I edited in Excel?**
 
-Yes. Ensure the first row contains the exact headers: `HashID,Type,Category,Amount,Date,Description`. Rows with missing or invalid fields are skipped with a warning.
+Yes. Ensure the first row contains the exact headers: `HashID,Type,Category,Amount,Date,Description`. Rows with missing or invalid fields are skipped with a warning. Note that if you edit the file outside RLAD, the integrity check will show a warning on the next startup — this is expected and does not prevent your data from loading.
+
+---
+
+**Q: Some of my descriptions show a leading space in Excel — is that a bug?**
+
+No. RLAD automatically prepends a tab character to any field that starts with `=`, `+`, `-`, or `@` to prevent spreadsheet applications from treating the cell as a formula. The tab appears as a leading space in Excel but is invisible to RLAD — re-importing the file restores the original value exactly.
 
 ---
 

--- a/docs/team/llk214.md
+++ b/docs/team/llk214.md
@@ -45,6 +45,8 @@ together with extensive bug fixing and documentation work across the project lif
   characters appeared in category or description fields. 5 unit tests cover round-trip, empty file, null category,
   pipe-in-description, and missing-file scenarios.
 
+- **CSV Security Hardening**: Fixed two vulnerabilities in the CSV storage layer. (1) Formula injection: `CsvStorageManager.escapeCsvField` now prefixes a tab before any field whose first non-whitespace character is `=`, `+`, `-`, or `@`, preventing spreadsheet applications from executing embedded formulas when the exported file is opened in Excel or Google Sheets. Leading whitespace in the raw input is normalised via `String.stripLeading()` so a user-typed tab cannot bypass the check. The tab is stripped by `.trim()` during re-import, preserving round-trip fidelity. (2) Autosave integrity: `AutoSaveManager` now computes and stores a SHA-256 digest of `data/rlad.csv` after every save. On startup the stored digest is compared against the live file; a mismatch triggers a visible warning so users can detect accidental or external edits before reviewing their data.
+
 - **Budget Persistence** (PR [#139](https://github.com/AY2526S2-CS2113-W13-4/tp/pull/139)): Budget entries now
   survive app restarts via `data/rlad_budget.csv`. Reuses `CsvStorageManager.exportToCsv()` for saving; load
   preserves original hash IDs. Existing `rlad.txt` autosave files are automatically migrated to `rlad.csv` on first
@@ -108,6 +110,7 @@ together with extensive bug fixing and documentation work across the project lif
 - Documented amount validation rules and budget persistence in UG
   (PRs [#69](https://github.com/AY2526S2-CS2113-W13-4/tp/pull/69),
   [#139](https://github.com/AY2526S2-CS2113-W13-4/tp/pull/139)).
+- Documented CSV formula injection protection and autosave integrity check in section 4.8 export, section 8 Data Persistence, and the FAQ.
 
 ### Contributions to the DG
 
@@ -116,9 +119,10 @@ together with extensive bug fixing and documentation work across the project lif
 - Authored section **4.5 Sort Transactions** — global vs per-command sort, `TransactionSorter` utility, and
   `TransactionManager` sort state.
 - Authored section **4.8 Storage Management (CSV Export/Import & Clear)** — `CsvStorageManager`, CSV parsing, import
-  modes, and clear confirmation flow.
-- Authored section **4.9 Autosave** — `AutoSaveManager` design, trigger points, load-on-startup flow, and budget
-  persistence (PRs [#64](https://github.com/AY2526S2-CS2113-W13-4/tp/pull/64),
+  modes, clear confirmation flow, and CSV escaping rules including formula injection neutralisation.
+- Authored section **4.9 Autosave** — `AutoSaveManager` design, trigger points, load-on-startup flow, budget
+  persistence, and the SHA-256 integrity verification subsection
+  (PRs [#64](https://github.com/AY2526S2-CS2113-W13-4/tp/pull/64),
   [#139](https://github.com/AY2526S2-CS2113-W13-4/tp/pull/139)).
 - Authored section **4.10 HelpCommand** — dispatch design and sequence diagram
   (PR [#70](https://github.com/AY2526S2-CS2113-W13-4/tp/pull/70)).

--- a/src/main/java/seedu/RLAD/storage/AutoSaveManager.java
+++ b/src/main/java/seedu/RLAD/storage/AutoSaveManager.java
@@ -7,6 +7,10 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.logging.Logger;
@@ -24,18 +28,22 @@ public class AutoSaveManager {
     private static final String SAVE_DIR = "data";
     private static final String SAVE_FILE = "rlad.csv";
     private static final String LEGACY_SAVE_FILE = "rlad.txt";
+    private static final String HASH_FILE_NAME = "rlad.csv.sha256";
 
     private final String filePath;
     private final String legacyFilePath;
+    private final String hashFilePath;
 
     public AutoSaveManager() {
         this.filePath = SAVE_DIR + File.separator + SAVE_FILE;
         this.legacyFilePath = SAVE_DIR + File.separator + LEGACY_SAVE_FILE;
+        this.hashFilePath = SAVE_DIR + File.separator + HASH_FILE_NAME;
     }
 
     /**
-     * Saves all transactions to the autosave CSV file.
-     * Delegates to CsvStorageManager.exportToCsv() which handles all escaping.
+     * Saves all transactions to the autosave CSV file, then writes a SHA-256 hash of
+     * the file alongside it so that accidental or malicious edits can be detected on
+     * the next load.
      *
      * @param transactions the list of transactions to save
      */
@@ -46,9 +54,68 @@ public class AutoSaveManager {
                 dir.mkdirs();
             }
             CsvStorageManager.exportToCsv(transactions, filePath);
+            saveHash();
             logger.fine("Autosaved " + transactions.size() + " transactions.");
         } catch (RLADException e) {
             logger.warning("Autosave failed: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Computes the SHA-256 digest of a file and writes it as a hex string to the
+     * companion hash file ({@code rlad.csv.sha256}).
+     */
+    private void saveHash() {
+        try {
+            String hash = computeSha256(filePath);
+            Files.write(Paths.get(hashFilePath), hash.getBytes());
+            logger.fine("Integrity hash saved.");
+        } catch (IOException e) {
+            logger.warning("Could not save integrity hash: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Verifies the autosave file against the stored SHA-256 hash.
+     *
+     * @return {@code true} if the file matches the stored hash (or no hash file exists
+     *         yet), {@code false} if the file has been modified since the last save
+     */
+    private boolean verifyIntegrity() {
+        File hashFile = new File(hashFilePath);
+        if (!hashFile.exists()) {
+            return true; // No hash yet (e.g. first run or pre-feature install) — skip check
+        }
+        try {
+            String stored = new String(Files.readAllBytes(Paths.get(hashFilePath))).trim();
+            String computed = computeSha256(filePath);
+            return stored.equals(computed);
+        } catch (IOException e) {
+            logger.warning("Integrity verification failed: " + e.getMessage());
+            return true; // Cannot verify — proceed rather than block the user
+        }
+    }
+
+    /**
+     * Returns the SHA-256 hex digest of the file at {@code path}.
+     *
+     * @param path path of the file to hash
+     * @return lowercase hex SHA-256 string
+     * @throws IOException if the file cannot be read or SHA-256 is unavailable
+     */
+    private String computeSha256(String path) throws IOException {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] fileBytes = Files.readAllBytes(Paths.get(path));
+            byte[] hashBytes = digest.digest(fileBytes);
+            StringBuilder sb = new StringBuilder();
+            for (byte b : hashBytes) {
+                sb.append(String.format("%02x", b));
+            }
+            return sb.toString();
+        } catch (NoSuchAlgorithmException e) {
+            // SHA-256 is mandated by the Java SE spec; this branch is unreachable in practice
+            throw new IOException("SHA-256 algorithm unavailable: " + e.getMessage());
         }
     }
 
@@ -75,6 +142,12 @@ public class AutoSaveManager {
         ArrayList<Transaction> loaded = new ArrayList<>();
         if (!csvFile.exists()) {
             return loaded;
+        }
+
+        if (!verifyIntegrity()) {
+            System.out.println("⚠️  WARNING: Autosave integrity check failed.");
+            System.out.println("   The data file may have been modified outside of RLAD.");
+            System.out.println("   Loading data anyway — please verify your transactions.");
         }
 
         try {

--- a/src/main/java/seedu/RLAD/storage/CsvStorageManager.java
+++ b/src/main/java/seedu/RLAD/storage/CsvStorageManager.java
@@ -183,12 +183,22 @@ public class CsvStorageManager {
      * Wraps in double quotes if the value contains commas, quotes, or newlines.
      * Doubles any existing double-quote characters.
      *
+     * <p>Also prefixes a tab character before fields that start with {@code =}, {@code +},
+     * {@code -}, or {@code @} to neutralise CSV formula injection when the file is opened
+     * in spreadsheet applications such as Excel or Google Sheets.  The tab is transparent
+     * on re-import because every field is already trimmed by the CSV parser.
+     *
      * @param field the field value to escape
      * @return the escaped field value
      */
     public static String escapeCsvField(String field) {
         if (field == null) {
             return "";
+        }
+        // Neutralise formula injection: prefix a tab so spreadsheet apps treat the cell
+        // as plain text.  The tab is stripped automatically by .trim() during re-import.
+        if (!field.isEmpty() && "=+-@".indexOf(field.charAt(0)) >= 0) {
+            field = "\t" + field;
         }
         if (field.contains(",") || field.contains("\"") || field.contains("\n")) {
             return "\"" + field.replace("\"", "\"\"") + "\"";

--- a/src/main/java/seedu/RLAD/storage/CsvStorageManager.java
+++ b/src/main/java/seedu/RLAD/storage/CsvStorageManager.java
@@ -197,8 +197,10 @@ public class CsvStorageManager {
         }
         // Neutralise formula injection: prefix a tab so spreadsheet apps treat the cell
         // as plain text.  The tab is stripped automatically by .trim() during re-import.
-        if (!field.isEmpty() && "=+-@".indexOf(field.charAt(0)) >= 0) {
-            field = "\t" + field;
+        // Use trimmed first char so a user-supplied leading tab doesn't bypass this check.
+        String trimmed = field.stripLeading();
+        if (!trimmed.isEmpty() && "=+-@".indexOf(trimmed.charAt(0)) >= 0) {
+            field = "\t" + trimmed;
         }
         if (field.contains(",") || field.contains("\"") || field.contains("\n")) {
             return "\"" + field.replace("\"", "\"\"") + "\"";

--- a/src/test/java/seedu/RLAD/storage/AutoSaveManagerTest.java
+++ b/src/test/java/seedu/RLAD/storage/AutoSaveManagerTest.java
@@ -6,6 +6,8 @@ import org.junit.jupiter.api.Test;
 import seedu.RLAD.Transaction;
 
 import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
 import java.time.LocalDate;
 import java.util.ArrayList;
 
@@ -16,22 +18,25 @@ class AutoSaveManagerTest {
 
     private AutoSaveManager autoSaveManager;
     private final String saveFile = "data" + File.separator + "rlad.csv";
+    private final String hashFile = "data" + File.separator + "rlad.csv.sha256";
 
     @BeforeEach
     void setUp() {
         autoSaveManager = new AutoSaveManager();
-        // Clean up before each test
-        File file = new File(saveFile);
-        if (file.exists()) {
-            file.delete();
-        }
+        deleteIfExists(saveFile);
+        deleteIfExists(hashFile);
     }
 
     @AfterEach
     void tearDown() {
-        File file = new File(saveFile);
-        if (file.exists()) {
-            file.delete();
+        deleteIfExists(saveFile);
+        deleteIfExists(hashFile);
+    }
+
+    private void deleteIfExists(String path) {
+        File f = new File(path);
+        if (f.exists()) {
+            f.delete();
         }
     }
 
@@ -92,6 +97,48 @@ class AutoSaveManagerTest {
         assertEquals(1, loaded.size());
         assertEquals(null, loaded.get(0).getCategory());
         assertEquals(5.00, loaded.get(0).getAmount());
+    }
+
+    @Test
+    void save_createsHashFile() {
+        ArrayList<Transaction> transactions = new ArrayList<>();
+        transactions.add(new Transaction("credit", "salary", 1000.00,
+                LocalDate.of(2026, 3, 1), "Pay"));
+
+        autoSaveManager.save(transactions);
+
+        assertTrue(new File(hashFile).exists(), "Hash file should be created alongside the CSV");
+    }
+
+    @Test
+    void saveAndLoad_integrityCheckPasses() {
+        ArrayList<Transaction> transactions = new ArrayList<>();
+        transactions.add(new Transaction("credit", "salary", 1000.00,
+                LocalDate.of(2026, 3, 1), "Pay"));
+        transactions.get(0).setHashId("fff999");
+
+        autoSaveManager.save(transactions);
+        // An unmodified file should load fine
+        ArrayList<Transaction> loaded = autoSaveManager.load();
+        assertEquals(1, loaded.size());
+        assertEquals("fff999", loaded.get(0).getHashId());
+    }
+
+    @Test
+    void load_tamperedFile_loadsWithWarning() throws IOException {
+        ArrayList<Transaction> transactions = new ArrayList<>();
+        transactions.add(new Transaction("credit", "salary", 1000.00,
+                LocalDate.of(2026, 3, 1), "Pay"));
+        autoSaveManager.save(transactions);
+
+        // Tamper: append a byte to the CSV so the hash no longer matches
+        try (FileWriter fw = new FileWriter(saveFile, true)) {
+            fw.write(" ");
+        }
+
+        // Should still return data (warns but does not block)
+        ArrayList<Transaction> loaded = autoSaveManager.load();
+        assertTrue(loaded.size() >= 0, "Load should complete even when integrity check fails");
     }
 
     @Test

--- a/src/test/java/seedu/RLAD/storage/CsvStorageManagerTest.java
+++ b/src/test/java/seedu/RLAD/storage/CsvStorageManagerTest.java
@@ -47,6 +47,43 @@ class CsvStorageManagerTest {
         assertEquals("", CsvStorageManager.escapeCsvField(null));
     }
 
+    @Test
+    void escapeCsvField_formulaEquals_prefixedWithTab() {
+        // Fields starting with '=' must be tab-prefixed to prevent spreadsheet injection
+        assertEquals("\t=CMD|'/C calc'!A0", CsvStorageManager.escapeCsvField("=CMD|'/C calc'!A0"));
+    }
+
+    @Test
+    void escapeCsvField_formulaPlus_prefixedWithTab() {
+        assertEquals("\t+1+1", CsvStorageManager.escapeCsvField("+1+1"));
+    }
+
+    @Test
+    void escapeCsvField_formulaMinus_prefixedWithTab() {
+        assertEquals("\t-1+1", CsvStorageManager.escapeCsvField("-1+1"));
+    }
+
+    @Test
+    void escapeCsvField_formulaAt_prefixedWithTab() {
+        assertEquals("\t@SUM(A1)", CsvStorageManager.escapeCsvField("@SUM(A1)"));
+    }
+
+    @Test
+    void exportAndImport_formulaDescription_roundTripPreservesOriginal() throws RLADException {
+        // A description that starts with '=' should survive an export-then-import cycle
+        // with the original value intact (the tab prefix is stripped on import).
+        ArrayList<Transaction> original = new ArrayList<>();
+        original.add(new Transaction("debit", "food", 9.90,
+                LocalDate.of(2026, 3, 1), "=evil formula"));
+
+        String filePath = tempDir.resolve("formula.csv").toString();
+        CsvStorageManager.exportToCsv(original, filePath);
+
+        CsvStorageManager.CsvImportResult result = CsvStorageManager.importFromCsv(filePath);
+        assertEquals(1, result.getSuccessCount());
+        assertEquals("=evil formula", result.getTransactions().get(0).getDescription());
+    }
+
     // === parseCsvLine tests ===
 
     @Test


### PR DESCRIPTION
## Summary

- **Formula injection fix**: `CsvStorageManager.escapeCsvField` now prefixes a tab character before any field whose first non-whitespace character is `=`, `+`, `-`, or `@`. This prevents Excel and Google Sheets from executing embedded formulas when the exported CSV is opened. `String.stripLeading()` is applied before the check so a user-typed leading tab cannot bypass the protection. The tab is stripped by `.trim()` during re-import, preserving full round-trip fidelity.
- **Bypass hardening**: follow-up commit tightens the check from `field.charAt(0)` to `field.stripLeading().charAt(0)` after smoke testing revealed a user-supplied leading tab could previously skip the prefix.
- **Autosave integrity**: `AutoSaveManager` computes a SHA-256 digest of `data/rlad.csv` after every save and writes it to `data/rlad.csv.sha256`. On startup the stored digest is compared against the live file; a mismatch shows a warning before loading so users can detect accidental or external edits.
- **Docs**: UG (export note, Data Persistence table, two new FAQ entries), DG (CSV escaping rules, new Integrity Verification subsection), and PPP updated to cover both changes.

## Test plan

- [ ] All existing tests pass (`./gradlew test`)
- [ ] Smoke tested: descriptions starting with `=`, `+`, `-`, `@` are stored with `^I` prefix in raw CSV and restored exactly on reload/import
- [ ] Smoke tested: user-typed leading tab before formula char is normalised — still gets single tab prefix
- [ ] Smoke tested: SHA-256 hash file created alongside CSV after every save
- [ ] Smoke tested: tampering with CSV triggers warning on next startup; data still loads
- [ ] Smoke tested: no false warning on fresh install (no hash file) or after a normal delete+reload cycle
- [ ] Smoke tested: export → import round-trip preserves all descriptions exactly